### PR TITLE
provider makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,6 @@ azure-native: bin/pulumi-java-gen
 google-native: bin/pulumi-java-gen
 	-$(call generate_sdk,google-native,https://raw.githubusercontent.com/pulumi/pulumi-google-native/master/provider/cmd/pulumi-resource-google-native/schema.json)
 
-bin/pulumi-java-gen: bin
-	cd pkg && go build -o ../bin/ github.com/pulumi/pulumi-java/pkg/cmd/pulumi-java-gen
-
-bin:
-	mkdir -p bin
-
 # Integration tests will use PULUMI_ACCESS_TOKEN to provision tests
 # stacks in Pulumi service.
 integration_tests::	bin/pulumi-language-jvm ensure_tests install_random


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
A makefile to try to make providers. All except `google-native` `azure-native` complete on @t0yv0  #40 

```
kdixler@kdixler-20xw004aus ~/Documents/pulumi-java (git)-[t0yv0/duplicate-file-issue] % make providers_all    
rm -rf ./providers/./aws-native
mkdir ./providers/./aws-native
curl https://raw.githubusercontent.com/pulumi/pulumi-aws-native/master/provider/cmd/pulumi-resource-aws-native/schema.json -o ./bin/aws-native-schema.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4613k  100 4613k    0     0  6001k      0 --:--:-- --:--:-- --:--:-- 5999k
./bin/pulumi-java-gen -schema ./bin/aws-native-schema.json -out ./providers/aws-native
rm -rf ./providers/./kubernetes
mkdir ./providers/./kubernetes
curl https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/provider/cmd/pulumi-resource-kubernetes/schema.json -o ./bin/kubernetes-schema.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2895k  100 2895k    0     0  5319k      0 --:--:-- --:--:-- --:--:-- 5322k
./bin/pulumi-java-gen -schema ./bin/kubernetes-schema.json -out ./providers/kubernetes
rm -rf ./providers/./azure-native
mkdir ./providers/./azure-native
curl https://raw.githubusercontent.com/pulumi/pulumi-azure-native/master/provider/cmd/pulumi-resource-azure-native/schema.json -o ./bin/azure-native-schema.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 33.5M  100 33.5M    0     0  7001k      0  0:00:04  0:00:04 --:--:-- 7187k
./bin/pulumi-java-gen -schema ./bin/azure-native-schema.json -out ./providers/azure-native
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xcf5c06]

goroutine 1 [running]:
github.com/pulumi/pulumi-java/pkg/codegen/jvm.(*modContext).genType(0xc0002f9590, {0x105f340, 0xc0061efbc0}, 0x0, {0xee99e8, 0x6}, 0x1, 0x0)
        /home/kdixler/Documents/pulumi-java/pkg/codegen/jvm/gen.go:1396 +0x66
github.com/pulumi/pulumi-java/pkg/codegen/jvm.(*modContext).gen(0xc0002f9590, 0xc0061ee480)
        /home/kdixler/Documents/pulumi-java/pkg/codegen/jvm/gen.go:1851 +0x1951
github.com/pulumi/pulumi-java/pkg/codegen/jvm.GeneratePackage({0xef3e92, 0xc}, 0xc00a691b80, 0xc)
        /home/kdixler/Documents/pulumi-java/pkg/codegen/jvm/gen.go:2189 +0x265
main.generateJava({0x7ffee8b9714c, 0x18}, {0x7ffee8b97128, 0x1e})
        /home/kdixler/Documents/pulumi-java/pkg/cmd/pulumi-java-gen/main.go:78 +0x270
main.main()
        /home/kdixler/Documents/pulumi-java/pkg/cmd/pulumi-java-gen/main.go:36 +0x185
make: [Makefile:66: azure-native] Error 2 (ignored)
rm -rf ./providers/./google-native
mkdir ./providers/./google-native
curl https://raw.githubusercontent.com/pulumi/pulumi-google-native/master/provider/cmd/pulumi-resource-google-native/schema.json -o ./bin/google-native-schema.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24.8M  100 24.8M    0     0  6883k      0  0:00:03  0:00:03 --:--:-- 6882k
./bin/pulumi-java-gen -schema ./bin/google-native-schema.json -out ./providers/google-native
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xcf5c06]

goroutine 1 [running]:
github.com/pulumi/pulumi-java/pkg/codegen/jvm.(*modContext).genType(0xc0068b3860, {0x105f340, 0xc006fe1080}, 0x0, {0xee99e8, 0x6}, 0x1, 0x0)
        /home/kdixler/Documents/pulumi-java/pkg/codegen/jvm/gen.go:1396 +0x66
github.com/pulumi/pulumi-java/pkg/codegen/jvm.(*modContext).gen(0xc0068b3860, 0xc006f8e2d0)
        /home/kdixler/Documents/pulumi-java/pkg/codegen/jvm/gen.go:1851 +0x1951
github.com/pulumi/pulumi-java/pkg/codegen/jvm.GeneratePackage({0xef3e92, 0xd}, 0xc000144840, 0x13)
        /home/kdixler/Documents/pulumi-java/pkg/codegen/jvm/gen.go:2189 +0x265
main.generateJava({0x7ffdf87a414b, 0x19}, {0x7ffdf87a4126, 0x1f})
        /home/kdixler/Documents/pulumi-java/pkg/cmd/pulumi-java-gen/main.go:78 +0x270
main.main()
        /home/kdixler/Documents/pulumi-java/pkg/cmd/pulumi-java-gen/main.go:36 +0x185
make: [Makefile:69: google-native] Error 2 (ignored)
```
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
