### PR TITLE
Port SDK changes v3.5.1-v3.6.0

### DIFF
--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/DeploymentImpl.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/DeploymentImpl.java
@@ -1346,9 +1346,15 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
          */
         private final Map<CompletableFuture<Void>, List<String>> inFlightTasks = new ConcurrentHashMap<>();
 
+        private final List<Exception> swallowedExceptions = new ArrayList<>();
+
         public DefaultRunner(DeploymentState deployment, Logger standardLogger) {
             this.engineLogger = Objects.requireNonNull(Objects.requireNonNull(deployment).logger);
             this.standardLogger = Objects.requireNonNull(standardLogger);
+        }
+
+        public List<Exception> getSwallowedExceptions() {
+            return ImmutableList.copyOf(this.swallowedExceptions);
         }
 
         /**
@@ -1488,6 +1494,8 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
         }
 
         private CompletableFuture<Integer> handleExceptionAsync(Exception exception) {
+            this.swallowedExceptions.add(exception);
+
             Function<Void, Integer> exitMessageAndCode = unused -> {
                 standardLogger.log(Level.FINE, "Returning from program after last error");
                 return ProcessExitedAfterLoggingUserActionableMessage;

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/Runner.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/Runner.java
@@ -4,12 +4,15 @@ import io.pulumi.Stack;
 import io.pulumi.resources.StackOptions;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 public interface Runner {
+    List<Exception> getSwallowedExceptions();
+
     <T> void registerTask(String description, CompletableFuture<T> task);
 
     CompletableFuture<Integer> runAsyncFuture(Supplier<CompletableFuture<Map<String, Optional<Object>>>> callback, @Nullable StackOptions options);
@@ -18,5 +21,5 @@ public interface Runner {
 
     <T extends Stack> CompletableFuture<Integer> runAsync(Supplier<T> stackFactory);
 
-//    <T extends Stack> CompletableFuture<Integer> runAsync(ServiceProvider serviceProvider); // TODO ?!
+//    <T extends Stack> CompletableFuture<Integer> runAsync(ServiceProvider serviceProvider); // TODO: not sure how ServiceProvider translates to Java, is it needed?
 }


### PR DESCRIPTION
- only SDK changes
- no Automation API

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Part of #53 

https://github.com/pulumi/pulumi/compare/v3.5.1...v3.6.0

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
