### PR TITLE
Port SDK changes v3.8.0-v3.9.0

### DIFF
--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/core/Tuples.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/core/Tuples.java
@@ -4,10 +4,13 @@ import com.google.common.base.MoreObjects;
 
 import java.util.Objects;
 
+// TODO: consider making this class a package, would it make it a better API?
 public class Tuples {
 
     public interface Tuple {
         // Empty
+
+        // TODO: consider moving TupleX factory methods here to get better usage: Tuple.of, instead of Tuples.of
     }
 
     public static final class Tuple0 implements Tuple {

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/resources/internal/DependencyProviderResource.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/resources/internal/DependencyProviderResource.java
@@ -2,6 +2,8 @@ package io.pulumi.resources.internal;
 
 import com.google.common.collect.ImmutableSet;
 import io.pulumi.core.OutputDefault;
+import io.pulumi.core.Tuples;
+import io.pulumi.core.Tuples.Tuple2;
 import io.pulumi.resources.ProviderResource;
 import io.pulumi.resources.Resource;
 import io.pulumi.resources.ResourceArgs;
@@ -13,8 +15,27 @@ import io.pulumi.resources.ResourceArgs;
  */
 public final class DependencyProviderResource extends ProviderResource {
     public DependencyProviderResource(String reference) {
-        super("", "", ResourceArgs.Empty, /* no options */ null, true);
+        super(parsePackage(reference), "", ResourceArgs.Empty, /* no options */ null, true);
 
+        var urnAndId = parseReference(reference);
+
+        ImmutableSet<Resource> resources = ImmutableSet.of(this);
+        this.setUrn(OutputDefault.of(resources, urnAndId.t1));
+        this.setId(OutputDefault.of(resources, urnAndId.t2));
+    }
+
+    private static String parsePackage(String reference) {
+        var urn = parseReference(reference).t1;
+        var urnParts = urn.split("::");
+        var qualifiedType = urnParts[2];
+        var qualifiedTypeParts = qualifiedType.split("\\$");
+        var type = qualifiedTypeParts[qualifiedTypeParts.length - 1];
+        var typeParts = type.split(":");
+        // type will be "pulumi:providers:<package>" and we want the last part.
+        return typeParts.length > 2 ? typeParts[2] : "";
+    }
+
+    private static Tuple2<String, String> parseReference(String reference) {
         var lastSep = reference.lastIndexOf("::");
         if (lastSep == -1) {
             throw new IllegalArgumentException(
@@ -22,9 +43,6 @@ public final class DependencyProviderResource extends ProviderResource {
         }
         var urn = reference.substring(0, lastSep);
         var id = reference.substring(lastSep + 2);
-
-        ImmutableSet<Resource> resources = ImmutableSet.of(this);
-        this.setUrn(OutputDefault.of(resources, urn));
-        this.setId(OutputDefault.of(resources, id));
+        return Tuples.of(urn, id);
     }
 }

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/resources/DependencyProviderResourceTests.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/resources/DependencyProviderResourceTests.java
@@ -1,0 +1,15 @@
+package io.pulumi.resources;
+
+import io.pulumi.resources.internal.DependencyProviderResource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DependencyProviderResourceTests {
+
+    @Test
+    void testGetPackage() {
+        var res = new DependencyProviderResource("urn:pulumi:stack::project::pulumi:providers:aws::default_4_13_0");
+        assertThat(res.accept(ProviderResource.packageVisitor())).isEqualTo("aws");
+    }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

- DependencyProviderResource improvements

Part of #54 

https://github.com/pulumi/pulumi/compare/v3.8.0...v3.9.0

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
