### PR TITLE
Give build more memory

### DIFF
--- a/pkg/codegen/jvm/templates.go
+++ b/pkg/codegen/jvm/templates.go
@@ -134,6 +134,11 @@ java {
     }
 }
 
+compileJava {
+    options.fork = true
+    options.forkOptions.jvmArgs.addAll(["-Xmx4g"])
+}
+
 repositories {
   maven { // The google mirror is less flaky than mavenCentral()
       url("https://maven-central.storage-download.googleapis.com/maven2/")

--- a/pkg/codegen/testing/test/testdata/mini-azurenative/jvm/build.gradle
+++ b/pkg/codegen/testing/test/testdata/mini-azurenative/jvm/build.gradle
@@ -12,6 +12,11 @@ java {
     }
 }
 
+compileJava {
+    options.fork = true
+    options.forkOptions.jvmArgs.addAll(["-Xmx4g"])
+}
+
 repositories {
   maven { // The google mirror is less flaky than mavenCentral()
       url("https://maven-central.storage-download.googleapis.com/maven2/")

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/jvm/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/jvm/build.gradle
@@ -12,6 +12,11 @@ java {
     }
 }
 
+compileJava {
+    options.fork = true
+    options.forkOptions.jvmArgs.addAll(["-Xmx4g"])
+}
+
 repositories {
   maven { // The google mirror is less flaky than mavenCentral()
       url("https://maven-central.storage-download.googleapis.com/maven2/")

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/jvm/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/jvm/build.gradle
@@ -12,6 +12,11 @@ java {
     }
 }
 
+compileJava {
+    options.fork = true
+    options.forkOptions.jvmArgs.addAll(["-Xmx4g"])
+}
+
 repositories {
   maven { // The google mirror is less flaky than mavenCentral()
       url("https://maven-central.storage-download.googleapis.com/maven2/")

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/jvm/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/jvm/build.gradle
@@ -12,6 +12,11 @@ java {
     }
 }
 
+compileJava {
+    options.fork = true
+    options.forkOptions.jvmArgs.addAll(["-Xmx4g"])
+}
+
 repositories {
   maven { // The google mirror is less flaky than mavenCentral()
       url("https://maven-central.storage-download.googleapis.com/maven2/")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #89 

We can add customization settings for this later. We can unblock getting providers built by just defaulting to more memory. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
