### PR TITLE
Port SDK changes v3.11.0-v3.15.0

### DIFF
--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/Deployment.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/Deployment.java
@@ -52,6 +52,22 @@ public interface Deployment {
     /**
      * Dynamically invokes the function {@code token}, which is offered by a provider plugin.
      * <p>
+     * The result of {@code invoke} will be an @see {@link Output<T>} resolved to the
+     * result value of the provider plugin.
+     * <p>
+     * The {@code args} inputs can be a bag of computed values
+     * (including, {@code T}s, @see {@link CompletableFuture}s, @see {@link io.pulumi.core.Output}s, etc.)
+     */
+    <T> Output<T> invoke(String token, TypeShape<T> targetType, InvokeArgs args, @Nullable InvokeOptions options);
+
+    /**
+     * Same as @see {@link #invoke(String, TypeShape, InvokeArgs, InvokeOptions)}
+     */
+    <T> Output<T> invoke(String token, TypeShape<T> targetType, InvokeArgs args);
+
+    /**
+     * Dynamically invokes the function {@code token}, which is offered by a provider plugin.
+     * <p>
      * The result of {@code invokeAsync} will be a @see {@link CompletableFuture} resolved to the
      * result value of the provider plugin.
      * <p>

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/DeploymentInstanceInternal.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/DeploymentInstanceInternal.java
@@ -48,6 +48,16 @@ public final class DeploymentInstanceInternal implements DeploymentInstance {
     }
 
     @Override
+    public <T> Output<T> invoke(String token, TypeShape<T> targetType, InvokeArgs args, @Nullable InvokeOptions options) {
+        return deployment.invoke(token, targetType, args, options);
+    }
+
+    @Override
+    public <T> Output<T> invoke(String token, TypeShape<T> targetType, InvokeArgs args) {
+        return deployment.invoke(token, targetType, args);
+    }
+
+    @Override
     public <T> CompletableFuture<T> invokeAsync(String token, TypeShape<T> targetType, InvokeArgs args, InvokeOptions options) {
         return deployment.invokeAsync(token, targetType, args, options);
     }

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/resources/InvokeArgs.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/resources/InvokeArgs.java
@@ -1,7 +1,5 @@
 package io.pulumi.resources;
 
-import io.pulumi.core.Input;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -16,9 +14,6 @@ public abstract class InvokeArgs extends InputArgs {
 
     @Override
     protected void validateMember(Class<?> memberType, String fullName) {
-        if (Input.class.isAssignableFrom(memberType)) {
-            throw new UnsupportedOperationException(
-                    String.format("'%s' must not be an Input<T>", fullName));
-        }
+        // No validation. A member may or may not be Input.
     }
 }

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/serialization/internal/Converter.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/serialization/internal/Converter.java
@@ -76,8 +76,13 @@ public class Converter {
             ));
         }
 
+        var mergedResources = ImmutableSet.<Resource>builder()
+                .addAll(resources)
+                .addAll(data.getResources())
+                .build();
+
         //noinspection unchecked
-        return InputOutputData.ofNullable(resources, (T) converted, data.isKnown(), data.isSecret());
+        return InputOutputData.ofNullable(mergedResources, (T) converted, data.isKnown(), data.isSecret());
     }
 
     @Nullable


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

- Add replaceOnChanges to the .NET SDK
- Added Output<T> Invoke.invoke(...)

Part of #54 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
