### PR TITLE
Fix orphaned output tests

### DIFF
--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/deployment/DeploymentTest.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/deployment/DeploymentTest.java
@@ -122,19 +122,18 @@ public class DeploymentTest {
         runTaskOne.join();
     }
 
-    // FIXME
-    @Disabled
     @Test
     void testRunWaitsForOrphanedOutput() {
         final var result = new AtomicInteger(0);
         var cf = new CompletableFuture<Integer>();
         var runTaskOne = mock.getRunner().runAsyncFuture(() -> {
             //noinspection unused
-            Output<Integer> orphaned = Output.of(cf).applyValue(result::getAndSet);
-            return CompletableFuture.completedFuture(Map.of());
+            Output<Integer> orphaned = Output.of(cf).applyValue(result::getAndSet); // the orphaned output
+            return CompletableFuture.completedFuture(Map.of()); // empty outputs
         }, null);
 
-        cf.complete(42);
+        var triggered = cf.complete(42);
+        assertThat(triggered).isTrue();
         runTaskOne.join();
 
         assertThat(result.get()).isEqualTo(42);


### PR DESCRIPTION
- task runner is now truly asynchronous

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fix orphaned output tests. Task runner is now truly asynchronous.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
