### PR TITLE
CloudFuture experiment

### DIFF
--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/core/CloudFuture.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/core/CloudFuture.java
@@ -1,0 +1,55 @@
+package io.pulumi.core;
+
+import io.pulumi.core.internal.InputOutputData;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.BiFunction;
+
+public interface CloudFuture<T>  {
+    CompletableFuture<InputOutputData<T>> toCompletableFuture();
+    CloudFutureContext getContext();
+
+    default <U> CloudFuture<U> thenApply(Function<? super T,? extends U> fn) {
+        return CloudFuture.of(getContext(), toCompletableFuture().thenApply(x -> x.map(fn)));
+    }
+
+    default <U,V> CloudFuture<V> thenCombine(CloudFuture<? extends U> other,
+                                             BiFunction<? super T,? super U,? extends V> fn) {
+        return CloudFuture.of(getContext(), toCompletableFuture()
+                .thenCombine(other.toCompletableFuture(), (x, y) -> x.combine(y, fn)));
+    }
+
+    default <U> CloudFuture<U> thenCompose(Function<? super T,? extends CloudFuture<U>> fn) {
+        return CloudFuture.of(getContext(), toCompletableFuture().thenCompose(rT ->
+                rT.traverseFuture(t -> fn.apply(t).toCompletableFuture()).thenApply(InputOutputData::join)
+        ));
+    }
+
+    static <T> CloudFuture<T> of(CloudFutureContext context, CompletableFuture<InputOutputData<T>> innerFuture) {
+        var future = new ResultFuture<T>(context, innerFuture);
+        context.registerFuture(innerFuture);
+        return future;
+    }
+
+    class ResultFuture<T> implements CloudFuture<T> {
+        private CompletableFuture<InputOutputData<T>> innerFuture;
+        private CloudFutureContext context;
+
+        ResultFuture(CloudFutureContext context, CompletableFuture<InputOutputData<T>> innerFuture) {
+            this.innerFuture = innerFuture;
+            this.context = context;
+        }
+
+        @Override
+        public CompletableFuture<InputOutputData<T>> toCompletableFuture() {
+            return innerFuture;
+        }
+
+        @Override
+        public CloudFutureContext getContext() {
+            return context;
+        }
+    }
+}
+

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/core/CloudFutureContext.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/core/CloudFutureContext.java
@@ -1,0 +1,16 @@
+package io.pulumi.core;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface CloudFutureContext {
+    <T> void registerFuture(CompletableFuture<T> future);
+
+    static CloudFutureContext ignore() {
+        return new IgnoreCloudFutureContext();
+    }
+
+    class IgnoreCloudFutureContext implements CloudFutureContext {
+        @Override
+        public <T> void registerFuture(CompletableFuture<T> future) {}
+    }
+}

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/core/CloudFutureTests.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/core/CloudFutureTests.java
@@ -1,0 +1,65 @@
+package io.pulumi.core;
+
+import io.pulumi.core.internal.InputOutputData;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class CloudFutureTests {
+
+    @Test
+    public void verifyThenApply() {
+        assert get(intFuture(1).thenApply(x -> x + 1)).orElse(-1) == 2;
+    }
+
+    @Test
+    public void verifyThenCombine() {
+        assert get(intFuture(1).thenCombine(intFuture(2), (x, y) -> x + y)).orElse(-1) == 3;
+    }
+
+    @Test
+    public void verifyThenCompose() {
+        assert get(intFuture(1).thenCompose(x -> intFuture(x + 1))).orElse(-1) == 2;
+    }
+
+    @Test
+    public void verifyAbilityToImplementCloudFutureInCustomClasses() {
+        var lst = new List123(CloudFutureContext.ignore());
+        assert get(lst).map(x -> x.get(0) + x.get(1) + x.get(2)).orElse(-1) == 1 + 2 + 3;
+    }
+
+    private CloudFuture<Integer> intFuture(int i) {
+        return CloudFuture.of(CloudFutureContext.ignore(), CompletableFuture.completedFuture(InputOutputData.of(i)));
+    }
+
+    private <T> Optional<T> get(CloudFuture<T> future) {
+        try {
+            return future.toCompletableFuture().get().getValueOptional();
+        } catch (InterruptedException e) {
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            return Optional.empty();
+        }
+    }
+
+    class List123 implements CloudFuture<List<Integer>> {
+        private CloudFutureContext context;
+
+        public List123(CloudFutureContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public CompletableFuture<InputOutputData<List<Integer>>> toCompletableFuture() {
+            return CompletableFuture.completedFuture(InputOutputData.of(List.of(1, 2, 3)));
+        }
+
+        @Override
+        public CloudFutureContext getContext() {
+            return this.context;
+        }
+    }
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Early days experiment inspired by discussion in https://github.com/pulumi/pulumi-java/issues/139

Naming TBD - `CloudFuture<T>` or `Output<T>` or something else, but this class to replace both Input and Output classes.

The idea is that this type is semantically equivalent to `CompletableFuture<InputOutputData<T>>` with the additional constraint that all new tasks are registered via `CompletableFutureContext.registerTask()` - which will be used by the framework to track completion of all tasks and do early termination on an exception. The context can further be extended if we need to coerce everything to a single Executor in the future.

So far only implemented the basis: `of` constructor and the triple of key combinators. The names of these are taken from:

https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html

```
   interface CompletionStage<T> {
      <U> CompletionStage<U> thenApply(Function<? super T,? extends U> fn)
      <U,V> CompletionStage<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T,? super U,? extends V> fn)
      <U> CompletionStage<U> thenCompose(Function<? super T,? extends CompletionStage<U>> fn)
   }
```

Perhaps these would be idiomatic Java names? 

| here | master | typescript |
| --- | --- | ----|
| x.thenApply(v -> v + 1) | x.applyValue(v -> v + 1) | x.apply(v => v + 1) |
| x.thenCombine(y, (v1,v2) -> v1 + v2) | ? | all([x, y]).apply(p => p[0] + p[1]) |
| x.thenCompose(v -> x) | x.applyInput(v -> x) | x.apply(v -> x) |

Open to jigger these, perhaps dropping `then`. 

If all other forms are implemented on top of this basis that'd be great - they will trivially maintain the desired semantics.

Where CompletionStage becomes a really helpful cheatsheet of other combinators.

```
thenAccept
thenAcceptBoth
thenRun
whenComplete
```

And so on.

Where CompletionStage is fundamentally more powerful than what Input/Output provides in Pulumi is just a few aspects:

1. exception control - ability to capture exceptions (e.g. whenComplete); this would require a bit of thinking because if we continue to naively capturing exceptions from all user code and terminating on first exception - this naively counteracts the ability provided by whenComplete; we also may just not implement it and be on par with other Pulumi SDKs

2. joining either-or (e.g. runAfterEither) - might be occasionally useful; trivial to add

Should we implement `CompletionStage` interface? It looks possible but not immediately obvious why useful. One potential problem is that `CompletableFuture<T> toCompletableFuture()` leaks out into the world that forgets resource tracking and we want to discourage that.


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
