### PR TITLE
Dixler/146/mark deprecates

### DIFF
--- a/pkg/codegen/jvm/gen.go
+++ b/pkg/codegen/jvm/gen.go
@@ -501,9 +501,7 @@ func (pt *plainType) genInputProperty(ctx *classFileContext, prop *schema.Proper
 		_, _ = fmt.Fprintf(w, "%s */\n", indent)
 	}
 
-	if prop.DeprecationMessage != "" {
-		_, _ = fmt.Fprintf(w, "%s@Deprecated\n", indent)
-	}
+	printObsoleteAttribute(ctx, prop.DeprecationMessage, indent)
 	_, _ = fmt.Fprintf(w, "%s@%s(name=\"%s\"%s)\n", indent, ctx.ref(names.InputImport), wireName, attributeArgs)
 	_, _ = fmt.Fprintf(w, "%sprivate final %s %s;\n", indent, propertyType.ToCode(ctx.imports), propertyName)
 	_, _ = fmt.Fprintf(w, "\n")
@@ -802,9 +800,7 @@ func (pt *plainType) genOutputType(ctx *classFileContext) error {
 			}
 			_, _ = fmt.Fprintf(w, "%s     */\n", indent)
 		}
-		if prop.DeprecationMessage != "" {
-			_, _ = fmt.Fprintf(w, "%s    @Deprecated\n", indent)
-		}
+		printObsoleteAttribute(ctx, prop.DeprecationMessage, indent+"    ")
 		_, _ = fmt.Fprintf(w, "%s    private final %s %s;\n", indent, fieldType.ToCode(ctx.imports), fieldName)
 	}
 	if len(props) > 0 {
@@ -935,9 +931,7 @@ func (pt *plainType) genOutputType(ctx *classFileContext) error {
 			}
 		}
 
-		if prop.DeprecationMessage != "" {
-			_, _ = fmt.Fprintf(w, "%s    @Deprecated\n", indent)
-		}
+		printObsoleteAttribute(ctx, prop.DeprecationMessage, indent+"    ")
 		if err := getterTemplate.Execute(w, getterTemplateContext{
 			Indent:          strings.Repeat("    ", 1),
 			GetterType:      getterType.ToCode(ctx.imports),
@@ -1214,9 +1208,7 @@ func (mod *modContext) genResource(ctx *classFileContext, r *schema.Resource, ar
 		outputParameterType := propertyType.ToCodeWithOptions(ctx.imports, TypeShapeStringOptions{
 			CommentOutAnnotations: true,
 		})
-		if prop.DeprecationMessage != "" {
-			_, _ = fmt.Fprintf(w, "    @Deprecated\n")
-		}
+		printObsoleteAttribute(ctx, prop.DeprecationMessage, "    ")
 		fmt.Fprintf(w,
 			"    @%s(name=\"%s\", type=%s, parameters={%s})\n",
 			ctx.ref(names.OutputExport), wireName, outputExportType, outputExportParameters)
@@ -1448,9 +1440,7 @@ func (mod *modContext) genFunction(ctx *classFileContext, fun *schema.Function, 
 	}
 
 	// Emit the datasource method.
-	if fun.DeprecationMessage != "" {
-		_, _ = fmt.Fprintf(w, "    @Deprecated\n")
-	}
+	printObsoleteAttribute(ctx, fun.DeprecationMessage, "    ")
 	_, _ = fmt.Fprintf(w, "    public static %s<%s> invokeAsync(%s@%s %s options) {\n",
 		ctx.ref(names.CompletableFuture), typeParameter, argsParamDef, ctx.ref(names.Nullable), ctx.ref(names.InvokeOptions))
 	_, _ = fmt.Fprintf(w,

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/jvm/src/main/java/io/pulumi/mypkg/GetAmiIds.java
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/jvm/src/main/java/io/pulumi/mypkg/GetAmiIds.java
@@ -27,7 +27,7 @@ public class GetAmiIds {
  * aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds
  * 
  */
-    @Deprecated
+    @Deprecated /* aws.getAmiIds has been deprecated in favor of aws.ec2.getAmiIds */
     public static CompletableFuture<GetAmiIdsResult> invokeAsync(GetAmiIdsArgs args, @Nullable InvokeOptions options) {
         return Deployment.getInstance().invokeAsync("mypkg::getAmiIds", TypeShape.of(GetAmiIdsResult.class), args == null ? GetAmiIdsArgs.Empty : args, Utilities.withVersion(options));
     }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #146 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
