### PR TITLE
[WIP] Improve type safety of Converter

### DIFF
--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/core/TypeShape.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/core/TypeShape.java
@@ -4,38 +4,57 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.pulumi.core.internal.Reflection;
 import io.pulumi.core.internal.annotations.InternalUse;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static io.pulumi.core.internal.PulumiCollectors.toSingleton;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 public final class TypeShape<T> {
 
     public static final TypeShape<Void> Empty = TypeShape.of(Void.class);
 
-    private final Class<? super T> type;
+    private final Class<T> type;
     private final ImmutableList<TypeShape<?>> parameters;
+    private final boolean nullable;
 
-    private TypeShape(Class<? super T> type) {
+    private final MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+    private TypeShape(Class<T> type) {
         this(type, ImmutableList.of());
     }
 
-    private TypeShape(Class<? super T> type, ImmutableList<TypeShape<?>> parameters) {
-        this.type = Objects.requireNonNull(type);
-        this.parameters = Objects.requireNonNull(parameters);
+    private TypeShape(Class<T> type, ImmutableList<TypeShape<?>> parameters) {
+        this.type = requireNonNull(type);
+        this.parameters = requireNonNull(parameters);
+        this.nullable = true;
+    }
+
+    private TypeShape(Class<T> type, ImmutableList<TypeShape<?>> parameters, boolean nullable) {
+        this.type = requireNonNull(type);
+        this.parameters = requireNonNull(parameters);
+        this.nullable = nullable;
     }
 
     public Class<T> getType() {
-        //noinspection unchecked
-        return (Class<T>) this.type;
+        return this.type;
+    }
+
+    public boolean isNullable() {
+        return nullable;
     }
 
     public String getTypeName() {
@@ -61,28 +80,205 @@ public final class TypeShape<T> {
         return this.parameters.size() > 0 || this.getType().getTypeParameters().length > 0;
     }
 
+    @InternalUse
     public <A extends Annotation> Optional<A> getAnnotation(Class<A> annotationType) {
         return Optional.ofNullable(this.getType().getAnnotation(annotationType));
     }
 
-    public <A extends Annotation> Constructor<?> getAnnotatedConstructor(Class<A> constructorAnnotation) {
+    @InternalUse
+    public <A extends Annotation> AnnotatedConstructor<T, A> getAnnotatedConstructor(Class<A> constructorAnnotation) {
         return Arrays.stream(this.type.getDeclaredConstructors())
                 .filter(c -> c.isAnnotationPresent(constructorAnnotation))
                 .peek(c -> c.setAccessible(true))
+                .map(c -> {
+                    try {
+                        return new AnnotatedConstructor<>(
+                                this,
+                                lookup.in(this.getType()).unreflectConstructor(c),
+                                c.getAnnotation(constructorAnnotation),
+                                extract(c.getParameterTypes(), c.getAnnotatedParameterTypes())
+                        );
+                    } catch (IllegalAccessException e) {
+                        throw new IllegalArgumentException(String.format(
+                                "Expected target type '%s' constructor annotated with '@%s; to be accessible, got: %s",
+                                getTypeName(), constructorAnnotation.getSimpleName(), e.getMessage()
+                        ), e);
+                    } finally {
+                        c.setAccessible(false);
+                    }
+                })
                 .collect(toSingleton(cause -> new IllegalArgumentException(String.format(
-                        "Expected target type '%s' to have exactly one constructor annotated with @%s, got: %s",
+                        "Expected target type '%s' to have an accessible constructor annotated with @%s, got: %s",
                         getTypeName(), constructorAnnotation.getSimpleName(), cause
                 ))));
     }
 
-    public <A extends Annotation> Method getAnnotatedMethod(Class<A> methodAnnotation) {
+    @InternalUse
+    public static final class AnnotatedConstructor<T, A extends Annotation> {
+
+        private final TypeShape<T> type;
+        private final MethodHandle constructor;
+        private final A annotation;
+        private final ImmutableList<TypeShape<?>> parameters;
+
+        public AnnotatedConstructor(TypeShape<T> type, MethodHandle constructor, A annotation, ImmutableList<TypeShape<?>> parameters) {
+            this.type = requireNonNull(type);
+            this.constructor = requireNonNull(constructor);
+            this.annotation = requireNonNull(annotation);
+            this.parameters = requireNonNull(parameters);
+
+            var length = this.constructor.type().parameterArray().length;
+            if (parameters.size() != length) {
+                throw new IllegalStateException(String.format(
+                        "Expected MethodHandle parameters to match reflection parameters, got %d and %d respectively.",
+                        parameters.size(), length
+                ));
+            }
+        }
+
+        public A getAnnotation() {
+            return this.annotation;
+        }
+
+        public ImmutableList<TypeShape<?>> getParameters() {
+            return this.parameters;
+        }
+
+        public T invoke(Object... args) {
+            if (this.parameters.size() != args.length) {
+                throw new IllegalArgumentException(String.format(
+                        "Expected constructor '%s' to be given %d arguments, got: %d",
+                        this.constructor, this.parameters.size(), args.length
+                ));
+            }
+            if (!Reflection.isAssignablePrimitiveFrom(this.type.type, this.constructor.type().returnType())) {
+                throw new IllegalStateException(String.format(
+                        "Expected the constructor '%s' return type '%s' match type shape '%s'",
+                        this.constructor, this.constructor.type().returnType(), this.type.getTypeName()
+                ));
+            }
+            for (int i = 0; i < this.parameters.size(); i++) {
+                TypeShape<?> p = this.parameters.get(i);
+                if (!Reflection.isAssignablePrimitiveFrom(p.type, args[i].getClass())) {
+                    throw new IllegalArgumentException(String.format(
+                            "Expected constructor '%s' to be given argument #%s (from 0) of type '%s', got '%s'",
+                            this.constructor, i, p.type.getTypeName(), args[i].getClass().getTypeName()
+                    ));
+                }
+            }
+            try {
+                //noinspection unchecked
+                return (T) this.constructor.invokeWithArguments(args);
+            } catch (Throwable e) {
+                throw new IllegalStateException(String.format(
+                        "Unexpected exception while invoking constructor '%s': %s",
+                        this.constructor, e.getMessage()
+                ), e);
+            }
+        }
+    }
+
+    @InternalUse
+    public <A extends Annotation> AnnotatedMethod<A> getAnnotatedMethod(Class<A> methodAnnotation) {
         return Arrays.stream(this.getType().getDeclaredMethods())
                 .filter(m -> m.isAnnotationPresent(methodAnnotation))
-                .peek(c -> c.setAccessible(true))
+                .peek(m -> m.setAccessible(true))
+                .map(m -> {
+                    try {
+                        return new AnnotatedMethod<>(
+                                lookup.in(this.getType()).unreflect(m),
+                                m.getAnnotation(methodAnnotation),
+                                // the first parameter is the self-reference type
+                                ImmutableList.<TypeShape<?>>builder()
+                                        .add(this)
+                                        .addAll(extract(m.getParameterTypes(), m.getAnnotatedParameterTypes()))
+                                        .build(),
+                                extract(m.getReturnType(), m.getAnnotatedReturnType())
+                        );
+                    } catch (IllegalAccessException e) {
+                        throw new IllegalArgumentException(String.format(
+                                "Expected target type '%s' to have an accessible method annotated with @%s, got error: %s",
+                                getTypeName(), methodAnnotation.getSimpleName(), e.getMessage()
+                        ), e);
+                    } finally {
+                        m.setAccessible(false);
+                    }
+                })
                 .collect(toSingleton(cause -> new IllegalArgumentException(String.format(
                         "Expected target type '%s' to have exactly one method annotated with @%s, got: %s",
                         getTypeName(), methodAnnotation.getSimpleName(), cause
                 ))));
+    }
+
+    @InternalUse
+    public static final class AnnotatedMethod<A extends Annotation> {
+        private final MethodHandle method;
+        private final A annotation;
+        private final ImmutableList<TypeShape<?>> parameters;
+        private final TypeShape<?> returnType;
+
+        public AnnotatedMethod(
+                MethodHandle method, A annotation, ImmutableList<TypeShape<?>> parameters, TypeShape<?> returnType
+        ) {
+            this.method = requireNonNull(method);
+            this.annotation = requireNonNull(annotation);
+            this.parameters = requireNonNull(parameters);
+
+            var length = this.method.type().parameterArray().length;
+            if (parameters.size() != length) {
+                throw new IllegalStateException(String.format(
+                        "Expected MethodHandle parameters to match reflection parameters, got %d and %d respectively.",
+                        parameters.size(), length
+                ));
+            }
+
+            this.returnType = requireNonNull(returnType);
+        }
+
+        public A getAnnotation() {
+            return this.annotation;
+        }
+
+        public ImmutableList<TypeShape<?>> getParameters() {
+            return this.parameters;
+        }
+
+        public TypeShape<?> getReturnType() {
+            return this.returnType;
+        }
+
+        // First argument is the self-reference
+        public Object invoke(Object... args) {
+            if (this.parameters.size() != args.length) {
+                throw new IllegalArgumentException(String.format(
+                        "Expected method '%s' to be given %d arguments, got: %d",
+                        this.method, this.parameters.size(), args.length
+                ));
+            }
+            if (!Reflection.isAssignablePrimitiveFrom(this.returnType.type, this.method.type().returnType())) {
+                throw new IllegalStateException(String.format(
+                        "Expected the method '%s' return type '%s' match return type shape '%s'",
+                        this.method, this.method.type().returnType(), this.returnType.getTypeName()
+                ));
+            }
+            for (int i = 0; i < this.parameters.size(); i++) {
+                TypeShape<?> p = this.parameters.get(i);
+                if (!Reflection.isAssignablePrimitiveFrom(p.type, args[i].getClass())) {
+                    throw new IllegalArgumentException(String.format(
+                            "Expected method '%s' to be given argument #%s (from 0) of type '%s', got '%s'",
+                            this.method, i, p.type.getTypeName(), args[i].getClass().getTypeName()
+                    ));
+                }
+            }
+            try {
+                return this.method.invokeWithArguments(args);
+            } catch (Throwable e) {
+                throw new IllegalStateException(String.format(
+                        "Unexpected exception while invoking method '%s': %s",
+                        this.method, e.getMessage()
+                ), e);
+            }
+        }
     }
 
     /**
@@ -90,19 +286,18 @@ public final class TypeShape<T> {
      *
      * @see Class#isAssignableFrom(Class)
      */
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public <U> boolean isAssignableFrom(TypeShape<U> other) {
-        if (!this.type.isAssignableFrom(other.type)) {
+    @InternalUse
+    public boolean isAssignablePrimitiveFrom(TypeShape<?> other) {
+        if (!Reflection.isAssignablePrimitiveFrom(this.type, other.type)) {
             return false;
         }
         if (this.getParameterCount() != other.getParameterCount()) {
             return false;
         }
-        ImmutableList<TypeShape<?>> typeShapes = this.getParameters();
         for (int i = 0; i < this.getParameters().size(); i++) {
             TypeShape<?> thisParam = this.getParameters().get(i);
             TypeShape<?> otherParam = other.getParameters().get(i);
-            if (!thisParam.isAssignableFrom(otherParam)) {
+            if (!thisParam.isAssignablePrimitiveFrom(otherParam)) {
                 return false;
             }
         }
@@ -123,22 +318,42 @@ public final class TypeShape<T> {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                .add("type", type)
-                .add("parameters", parameters)
+                .add("type", this.type)
+                .add("parameters", this.parameters)
+                .add("nullable", this.nullable)
                 .toString();
     }
 
-    public static TypeShape<?> extract(Parameter parameter) {
-        var parameterClass = parameter.getType();
-        var token = TypeToken.of(parameter.getParameterizedType());
-        return extract(parameterClass, token);
+    @InternalUse
+    private static ImmutableList<TypeShape<?>> extract(Class<?>[] typeClasses, AnnotatedType[] types) {
+        if (typeClasses.length != types.length) {
+            throw new IllegalStateException("Unexpected mismatch between class and type arrays.");
+        }
+
+        var builder = ImmutableList.<TypeShape<?>>builder();
+        for (int i = 0; i < typeClasses.length; i++) {
+            builder.add(extract(typeClasses[i], types[i]));
+        }
+        return builder.build();
     }
 
-    private static TypeShape<?> extract(Class<?> type, TypeToken<?> resolverToken) {
+    @SuppressWarnings("UnstableApiUsage")
+    @InternalUse
+    private static TypeShape<?> extract(Class<?> typeClass, AnnotatedType type) {
+        var token = TypeToken.of(type.getType());
+        var nullable = type.isAnnotationPresent(Nullable.class);
+        return extract(typeClass, token, nullable);
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    @InternalUse
+    private static TypeShape<?> extract(Class<?> type, TypeToken<?> resolverToken, boolean nullable) {
         var builder = TypeShape.builder(type);
+        builder.setNullable(nullable);
         for (var param : type.getTypeParameters()) {
+            var nullableParam = param.isAnnotationPresent(Nullable.class);
             var token = resolverToken.resolveType(param);
-            builder.addParameter(extract(token.getRawType(), token));
+            builder.addParameter(extract(token.getRawType(), token, nullableParam));
         }
         return builder.build();
     }
@@ -189,10 +404,17 @@ public final class TypeShape<T> {
 
         private final Class<? super T> type;
         private final ImmutableList.Builder<TypeShape<?>> parameters;
+        private boolean isNullable = true;
 
         private Builder(Class<? super T> type) {
-            this.type = Objects.requireNonNull(type);
+            this.type = requireNonNull(type);
             this.parameters = ImmutableList.builder();
+        }
+
+        @CanIgnoreReturnValue
+        public Builder<T> setNullable(boolean isNullable) {
+            this.isNullable = isNullable;
+            return this;
         }
 
         @CanIgnoreReturnValue
@@ -217,7 +439,8 @@ public final class TypeShape<T> {
 
         @CheckReturnValue
         public TypeShape<T> build() {
-            return new TypeShape<>(this.type, this.parameters.build());
+            //noinspection unchecked
+            return new TypeShape<>((Class<T>) this.type, this.parameters.build(), this.isNullable);
         }
     }
 }

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/core/internal/OutputCompletionSource.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/core/internal/OutputCompletionSource.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.pulumi.core.internal.Reflection.isAssignablePrimitiveFrom;
 
 @ParametersAreNonnullByDefault
 public class OutputCompletionSource<T> {
@@ -50,13 +51,13 @@ public class OutputCompletionSource<T> {
     }
 
     public void setObjectValue(Object value, TypeShape<?> valueShape, boolean isKnown) {
-        if (!dataTypeShape.getType().isAssignableFrom(value.getClass())) {
+        if (!isAssignablePrimitiveFrom(dataTypeShape.getType(), value.getClass())) {
             throw new IllegalArgumentException(String.format(
                     "Expected 'setObjectValue' with matching types, got 'OutputCompletionSource<%s>' and value class '%s",
                     value.getClass().getTypeName(), dataTypeShape.getType().getTypeName())
             );
         }
-        if (!dataTypeShape.isAssignableFrom(valueShape)) {
+        if (!dataTypeShape.isAssignablePrimitiveFrom(valueShape)) {
             throw new IllegalArgumentException(String.format(
                     "Expected 'setObjectValue' with matching types, got 'OutputCompletionSource<%s>' and value shape '%s'",
                     valueShape.asString(), dataTypeShape.asString())

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/core/TypeShapeTest.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/core/TypeShapeTest.java
@@ -1,0 +1,23 @@
+package io.pulumi.core;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeShapeTest {
+
+    @Test
+    void testTypeShapeToGSONConversion() {
+        var token = TypeShape.list(Integer.class).toGSON().getType();
+        var string = "[1,2,3,4]";
+
+        var gson = new Gson();
+        List<Integer> result = gson.fromJson(string, token);
+
+        assertThat(result).isNotNull();
+        assertThat(result).containsExactly(1, 2, 3, 4);
+    }
+}

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/core/internal/InputOutputMetadataTest.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/core/internal/InputOutputMetadataTest.java
@@ -132,7 +132,7 @@ class InputOutputMetadataTest {
         assertThat(complex2Info).isNotNull();
         assertThat(complex2Info.getName()).isEqualTo("complex2");
         assertThat(complex2Info.getFieldType()).isAssignableFrom(tester.explicitFoo.getClass());
-        assertThat(complex2Info.getDataShape().isAssignableFrom(TypeShape.either(Integer.class, String.class))).isTrue();
+        assertThat(complex2Info.getDataShape().isAssignablePrimitiveFrom(TypeShape.either(Integer.class, String.class))).isTrue();
         var complex2 = complex2Info.getFieldValue(tester);
         assertThat(complex2).isNotNull().isPresent();
         var complex2Value = Internal.of(complex2.get()).getValueNullable().join();

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/core/internal/ReflectionTest.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/core/internal/ReflectionTest.java
@@ -1,24 +1,47 @@
 package io.pulumi.core.internal;
 
-import com.google.gson.Gson;
-import io.pulumi.core.TypeShape;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
+import java.util.stream.Stream;
 
+import static io.pulumi.core.internal.Reflection.isAssignablePrimitiveFrom;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class ReflectionTest {
 
-    @Test
-    void testTypeShapeToGSONConversion() {
-        var token = TypeShape.list(Integer.class).toGSON().getType();
-        var string = "[1,2,3,4]";
-
-        var gson = new Gson();
-        List<Integer> result = gson.fromJson(string, token);
-
-        assertThat(result).isNotNull();
-        assertThat(result).containsExactly(1,2,3,4);
+    @SuppressWarnings("unused")
+    private static Stream<Arguments> testIsAssignablePrimitiveFrom() {
+        return Stream.of(
+                arguments(boolean.class, Boolean.class, true),
+                arguments(byte.class, Byte.class, true),
+                arguments(char.class, Character.class, true),
+                arguments(double.class, Double.class, true),
+                arguments(float.class, Float.class, true),
+                arguments(int.class, Integer.class, true),
+                arguments(long.class, Long.class, true),
+                arguments(short.class, Short.class, true),
+                arguments(Boolean.class, boolean.class, true),
+                arguments(Byte.class, byte.class, true),
+                arguments(Character.class, char.class, true),
+                arguments(Double.class, double.class, true),
+                arguments(Float.class, float.class, true),
+                arguments(Integer.class, int.class, true),
+                arguments(Long.class, long.class, true),
+                arguments(Short.class, short.class, true),
+                arguments(Boolean.class, Boolean.class, true),
+                arguments(boolean.class, boolean.class, true),
+                arguments(byte.class, boolean.class, false),
+                arguments(Byte.class, Boolean.class, false)
+        );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsAssignablePrimitiveFrom(Class<?> to, Class<?> from, boolean expected) {
+        assertThat(isAssignablePrimitiveFrom(to, from)).isEqualTo(expected);
+    }
+
 }

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/deployment/DeploymentInvokeTest.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/deployment/DeploymentInvokeTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -61,7 +62,7 @@ public class DeploymentInvokeTest {
     }
 
     static class CustomInvokes {
-        static Output<ImmutableList<ImmutableMap<String, Object>>> doStuff(
+        static Output<List<Map<String, Object>>> doStuff(
                 @SuppressWarnings("SameParameterValue") CustomArgs args,
                 @Nullable InvokeOptions options) {
             return Output.of(
@@ -94,10 +95,10 @@ public class DeploymentInvokeTest {
 
     @OutputCustomType
     static class CustomResult {
-        public final ImmutableList<ImmutableMap<String, Object>> result;
+        public final List<Map<String, Object>> result;
 
         @OutputCustomType.Constructor("result")
-        private CustomResult(ImmutableList<ImmutableMap<String, Object>> result) {
+        private CustomResult(List<Map<String, Object>> result) {
             this.result = result;
         }
     }

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/serialization/internal/ComplexTypeConverterTest.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/serialization/internal/ComplexTypeConverterTest.java
@@ -23,8 +23,8 @@ class ComplexTypeConverterTest {
         public final boolean b;
         public final int i;
         public final double d;
-        public final ImmutableList<Boolean> list;
-        public final ImmutableMap<String, Integer> map;
+        public final List<Boolean> list;
+        public final Map<String, Integer> map;
         public final Object obj;
         public final ContainerSize size;
         public final ContainerColor color;
@@ -32,7 +32,7 @@ class ComplexTypeConverterTest {
         @OutputCustomType.Constructor({"s", "b", "i", "d", "list", "map", "obj", "size", "color"})
         public ComplexType1(
                 String s, boolean b, int i, double d,
-                ImmutableList<Boolean> list, ImmutableMap<String, Integer> map, Object obj,
+                List<Boolean> list, Map<String, Integer> map, Object obj,
                 ContainerSize size, ContainerColor color
         ) {
             this.s = s;
@@ -82,14 +82,14 @@ class ComplexTypeConverterTest {
     @OutputCustomType
     public static class ComplexType2 {
         public final ComplexType1 c;
-        public final ImmutableList<ComplexType1> c2List;
-        public final ImmutableMap<String, ComplexType1> c2Map;
+        public final List<ComplexType1> c2List;
+        public final Map<String, ComplexType1> c2Map;
 
         @OutputCustomType.Constructor({"c", "c2List", "c2Map"})
         public ComplexType2(
                 ComplexType1 c,
-                ImmutableList<ComplexType1> c2List,
-                ImmutableMap<String, ComplexType1> c2Map)
+                List<ComplexType1> c2List,
+                Map<String, ComplexType1> c2Map)
         {
             this.c = c;
             this.c2List = c2List;

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/serialization/internal/ConverterTests.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/serialization/internal/ConverterTests.java
@@ -1,8 +1,6 @@
 package io.pulumi.serialization.internal;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.protobuf.ListValue;
@@ -33,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -416,7 +415,7 @@ class ConverterTests {
                             .putFields("__defaults", Value.newBuilder().setBoolValue(true).build())
                             .build()
             ).build();
-            var shape = TypeShape.builder(ImmutableMap.class)
+            var shape = TypeShape.builder(Map.class)
                     .addParameter(String.class)
                     .addParameter(String.class)
                     .build();
@@ -667,10 +666,10 @@ class ConverterTests {
     @OutputCustomType
     public static class RecursiveType {
         public final String ref;
-        public final ImmutableList<RecursiveType> additionalItems;
+        public final List<RecursiveType> additionalItems;
 
         @OutputCustomType.Constructor({"ref", "additionalItems"})
-        public RecursiveType(String ref, ImmutableList<RecursiveType> additionalItems) {
+        public RecursiveType(String ref, List<RecursiveType> additionalItems) {
             this.ref = ref;
             this.additionalItems = additionalItems;
         }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Improve type safety of Converter

- use MethodHandle instead of Reflection API when possible
- add isAssignablePrimitiveFrom to account for primitive types
- improve Converter error handling and typing

Related to #175

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
