### PR TITLE
[ci/tests] split apart CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,11 +52,13 @@ jobs:
       - name: Build Pulumi JVM Language Provider and Codegen
         run: make build_go
   test_go:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Test Pulumi JVM Language Provider and Codegen
         run: make test_go
   provider-random:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Build pulumi-random JVM SDK
@@ -64,6 +66,7 @@ jobs:
       - name: Install pulumi-random JVM SDK to a local Maven repo
         run: make provider.random.install
   provider-azure-native:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Build pulumi-azure-native JVM SDK
@@ -71,6 +74,7 @@ jobs:
       - name: Install pulumi-azure-native JVM SDK to a local Maven repo
         run: make provider.azure-native.install
   provider-google-native:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Build pulumi-google-native JVM SDK
@@ -78,6 +82,7 @@ jobs:
       - name: Install pulumi-google-native JVM SDK to a local Maven repo
         run: make provider.google-native.install
   provider-aws:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Build pulumi-aws JVM SDK
@@ -85,6 +90,7 @@ jobs:
       - name: Install pulumi-aws JVM SDK to a local Maven repo
         run: make provider.aws.install
   provider-aws-native:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Build pulumi-aws-native JVM SDK
@@ -92,6 +98,7 @@ jobs:
       - name: Install pulumi-aws-native JVM SDK to a local Maven repo
         run: make provider.aws-native.install
   provider-kubernetes:
+    runs-on: ubuntu-latest
     needs: build-base-java-sdk
     steps:
       - name: Build pulumi-kubernetes JVM SDK
@@ -99,6 +106,7 @@ jobs:
       - name: Install pulumi-kubernetes JVM SDK to a local Maven repo
         run: make provider.kubernetes.install
   integration-tests:
+    runs-on: ubuntu-latest
     steps:
       - name: Integration tests
         run: make integration_tests


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
WIP
- #47 adds making provider: aws-classic to CI
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #192 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
