### PR TITLE
Converter more permissive to nulls

### DIFF
--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/core/internal/OutputCompletionSource.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/core/internal/OutputCompletionSource.java
@@ -80,8 +80,10 @@ public class OutputCompletionSource<T> {
         ));
     }
 
-    public void setValue(String context, Value value, ImmutableSet<Resource> depsOrEmpty) {
-        setValue(Converter.convertValue(
+    public void setValue(Converter converter, String context, Value value, ImmutableSet<Resource> depsOrEmpty) {
+        // we need to call the converter here, inside this class where we know the T,
+        // the T type will get lost at the call site due to Java generics limitations
+        setValue(converter.convertValue(
                 context,
                 value,
                 getTypeShape(),

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/DeploymentTests.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/deployment/internal/DeploymentTests.java
@@ -11,6 +11,8 @@ import io.pulumi.deployment.Mocks;
 import io.pulumi.deployment.internal.DeploymentImpl.DefaultEngineLogger;
 import io.pulumi.exceptions.RunException;
 import io.pulumi.resources.Resource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -23,8 +25,6 @@ import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 public class DeploymentTests {
 
@@ -332,6 +332,10 @@ public class DeploymentTests {
 
     public static Log mockLog() {
         return mockLog(defaultLogger(), () -> Mockito.mock(Engine.class));
+    }
+
+    public static Log mockLog(Logger logger) {
+        return mockLog(logger, () -> Mockito.mock(Engine.class));
     }
 
     public static Log mockLog(Logger logger, Supplier<Engine> engine) {

--- a/sdk/jvm/pulumi/src/main/java/io/pulumi/serialization/internal/Converter.java
+++ b/sdk/jvm/pulumi/src/main/java/io/pulumi/serialization/internal/Converter.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.stream.JsonWriter;
 import com.google.protobuf.Value;
+import io.pulumi.Log;
 import io.pulumi.core.Archive;
 import io.pulumi.core.Archive.InvalidArchive;
 import io.pulumi.core.Asset.InvalidAsset;
@@ -29,6 +30,7 @@ import java.lang.reflect.Parameter;
 import java.util.*;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -37,25 +39,27 @@ import static java.util.stream.Collectors.joining;
 @ParametersAreNonnullByDefault
 public class Converter {
 
-    private Converter() {
-        throw new UnsupportedOperationException("static class");
+    private final Log log;
+
+    public Converter(Log log) {
+        this.log = requireNonNull(log);
     }
 
-    public static <T> InputOutputData<T> convertValue(String context, Value value, Class<T> targetType) {
+    public <T> InputOutputData<T> convertValue(String context, Value value, Class<T> targetType) {
         return convertValue(context, value, TypeShape.of(targetType));
     }
 
-    public static <T> InputOutputData<T> convertValue(String context, Value value, TypeShape<T> targetType) {
+    public <T> InputOutputData<T> convertValue(String context, Value value, TypeShape<T> targetType) {
         return convertValue(context, value, targetType, ImmutableSet.of());
     }
 
-    public static <T> InputOutputData<T> convertValue(
+    public <T> InputOutputData<T> convertValue(
             String context, Value value, TypeShape<T> targetType, ImmutableSet<Resource> resources
     ) {
-        Objects.requireNonNull(context);
-        Objects.requireNonNull(value);
-        Objects.requireNonNull(targetType);
-        Objects.requireNonNull(resources);
+        requireNonNull(context);
+        requireNonNull(value);
+        requireNonNull(targetType);
+        requireNonNull(resources);
 
         checkTargetType(context, targetType);
 
@@ -86,7 +90,7 @@ public class Converter {
     }
 
     @Nullable
-    private static Object convertObjectUntyped(String context, @Nullable Object value, TypeShape<?> targetType) {
+    private Object convertObjectUntyped(String context, @Nullable Object value, TypeShape<?> targetType) {
         try {
             return tryConvertObjectInner(context, value, targetType);
         } catch (UnsupportedOperationException ex) {
@@ -103,7 +107,7 @@ public class Converter {
     }
 
     @Nullable
-    private static Object tryConvertObjectInner(
+    private Object tryConvertObjectInner(
             String context, @Nullable Object value, TypeShape<?> targetType
     ) {
         var targetIsOptional = Optional.class.isAssignableFrom(targetType.getType());
@@ -329,22 +333,23 @@ public class Converter {
                             argValue,
                             TypeShape.extract(parameter)
                     );
-                } else if (parameter.isAnnotationPresent(Nullable.class)) {
-                    arguments[i] = null;
                 } else {
-                    throw new IllegalStateException(String.format(
-                            "Expected type '%s' (annotated with '%s') to provide a constructor annotated with '%s', " +
-                                    "and the parameter names in the annotation matching the parameters being deserialized. " +
-                                    "Constructor '%s' parameter named '%s' (nr %d starting from 0) lacks @%s annotation, " +
-                                    "so the value is required, but there is no value to deserialize.",
-                            targetType.getTypeName(),
-                            OutputCustomType.class.getTypeName(),
-                            OutputCustomType.Constructor.class.getTypeName(),
-                            constructor,
-                            parameterName,
-                            i,
-                            Nullable.class.getTypeName()
-                    ));
+                    arguments[i] = null;
+                    if (!parameter.isAnnotationPresent(Nullable.class)) {
+                        log.debug(String.format(
+                                "Expected type '%s' (annotated with '%s') to provide a constructor annotated with '%s', " +
+                                        "and the parameter names in the annotation matching the parameters being deserialized. " +
+                                        "Constructor '%s' parameter named '%s' (nr %d starting from 0) lacks @%s annotation, " +
+                                        "so the value is required, but there is no value to deserialize.",
+                                targetType.getTypeName(),
+                                OutputCustomType.class.getTypeName(),
+                                OutputCustomType.Constructor.class.getTypeName(),
+                                constructor,
+                                parameterName,
+                                i,
+                                Nullable.class.getTypeName()
+                        ));
+                    }
                 }
             }
 
@@ -364,7 +369,7 @@ public class Converter {
         }
     }
 
-    private static JsonElement tryConvertJsonElement(String context, Object value) {
+    private JsonElement tryConvertJsonElement(String context, Object value) {
         var gson = new Gson();
         StringWriter stringWriter = new StringWriter();
         try {
@@ -376,7 +381,7 @@ public class Converter {
         return gson.fromJson(stringWriter.toString(), JsonElement.class);
     }
 
-    private static void tryWriteJson(String context, JsonWriter jsonWriter, @Nullable Object value) throws IOException {
+    private void tryWriteJson(String context, JsonWriter jsonWriter, @Nullable Object value) throws IOException {
         if (value == null) {
             jsonWriter.nullValue();
             return;
@@ -423,7 +428,7 @@ public class Converter {
         ));
     }
 
-    private static <T> T tryEnsureType(String context, Object value, TypeShape<T> targetType) {
+    private <T> T tryEnsureType(String context, Object value, TypeShape<T> targetType) {
         if (targetType.getType().isInstance(value)
                 || (boolean.class.isAssignableFrom(targetType.getType()) && value instanceof Boolean)
                 || (double.class.isAssignableFrom(targetType.getType()) && value instanceof Double)
@@ -439,7 +444,7 @@ public class Converter {
         }
     }
 
-    private static Either<Object, Object> tryConvertOneOf(String context, Object value, TypeShape<?> targetType) {
+    private Either<Object, Object> tryConvertOneOf(String context, Object value, TypeShape<?> targetType) {
         var leftType = targetType.getParameter(0)
                 .orElseThrow(() -> new IllegalStateException("Expected a left parameter type for the Either, got none"));
         var rightType = targetType.getParameter(1)
@@ -471,7 +476,7 @@ public class Converter {
         }
     }
 
-    private static ImmutableList<Object> tryConvertList(String context, Object value, TypeShape<?> targetType) {
+    private ImmutableList<Object> tryConvertList(String context, Object value, TypeShape<?> targetType) {
         if (!List.class.isAssignableFrom(value.getClass())) {
             throw new IllegalArgumentException(String.format(
                     "%s; Expected List but got '%s' while deserializing", context, value.getClass().getTypeName()
@@ -493,7 +498,7 @@ public class Converter {
         return builder.build();
     }
 
-    private static ImmutableMap<String, Object> tryConvertMap(String context, Object value, TypeShape<?> targetType) {
+    private ImmutableMap<String, Object> tryConvertMap(String context, Object value, TypeShape<?> targetType) {
         if (!Map.class.isAssignableFrom(value.getClass())) {
             throw new IllegalArgumentException(String.format(
                     "%s; Expected Map but got '%s' while deserializing", context, value.getClass().getTypeName()
@@ -516,14 +521,12 @@ public class Converter {
         return builder.build();
     }
 
-    // TODO
-
-    public static void checkTargetType(String context, TypeShape<?> targetType) {
+    public void checkTargetType(String context, TypeShape<?> targetType) {
         checkTargetType(context, targetType, new HashSet<>());
     }
 
     // pre-check for performance reasons
-    public static void checkTargetType(String context, TypeShape<?> targetType, HashSet<Class<?>> seenTypes) {
+    public void checkTargetType(String context, TypeShape<?> targetType, HashSet<Class<?>> seenTypes) {
 
         // types can be recursive.  So only dive into a type if it's the first time we're seeing it.
         if (!seenTypes.add(targetType.getType())) {

--- a/sdk/jvm/pulumi/src/test/java/io/pulumi/serialization/internal/ConverterTests.java
+++ b/sdk/jvm/pulumi/src/test/java/io/pulumi/serialization/internal/ConverterTests.java
@@ -122,8 +122,9 @@ class ConverterTests {
         void testInvokeArgs() {
             var gson = new Gson();
             var args = new ComplexInvokeArgs1(new SimpleInvokeArgs1("value1"));
+            var converter = new Converter(log);
             serializeToValueAsync(args)
-                    .thenApply(value -> Converter.convertValue("ArgsConverterTests", value, JsonElement.class))
+                    .thenApply(value -> converter.convertValue("ArgsConverterTests", value, JsonElement.class))
                     .thenAccept(data ->
                             assertThat(data.getValueNullable())
                                     .isEqualTo(gson.fromJson("{\"v\"={\"s\"=\"value1\"}}", JsonElement.class))
@@ -134,8 +135,9 @@ class ConverterTests {
         void testResourceArgs() {
             var gson = new Gson();
             var args = new ComplexResourceArgs1(Input.of(new SimpleResourceArgs1(Input.of("value2"))));
+            var converter = new Converter(log);
             serializeToValueAsync(args)
-                    .thenApply(value -> Converter.convertValue("ArgsConverterTests", value, JsonElement.class))
+                    .thenApply(value -> converter.convertValue("ArgsConverterTests", value, JsonElement.class))
                     .thenAccept(data ->
                             assertThat(data.getValueNullable())
                                     .isEqualTo(gson.fromJson("{\"v\"={\"s\"=\"value2\"}}", JsonElement.class))
@@ -154,7 +156,8 @@ class ConverterTests {
         @Test
         void testTrue() {
             var trueValue = Value.newBuilder().setBoolValue(true).build();
-            var data = Converter.convertValue(
+            var converter = new Converter(log);
+            var data = converter.convertValue(
                     "BooleanConverterTests", trueValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isTrue();
@@ -164,7 +167,8 @@ class ConverterTests {
         @Test
         void testFalse() {
             var falseValue = Value.newBuilder().setBoolValue(false).build();
-            var data = Converter.convertValue(
+            var converter = new Converter(log);
+            var data = converter.convertValue(
                     "BooleanConverterTests", falseValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isFalse();
@@ -174,7 +178,8 @@ class ConverterTests {
         @Test
         void testTrueSecret() {
             var secretValue = createSecretValue(Value.newBuilder().setBoolValue(true).build());
-            var data = Converter.convertValue(
+            var converter = new Converter(log);
+            var data = converter.convertValue(
                     "BooleanConverterTests", secretValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isTrue();
@@ -185,7 +190,8 @@ class ConverterTests {
         @Test
         void testFalseSecret() {
             var secretValue = createSecretValue(Value.newBuilder().setBoolValue(false).build());
-            var data = Converter.convertValue(
+            var converter = new Converter(log);
+            var data = converter.convertValue(
                     "BooleanConverterTests", secretValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isFalse();
@@ -196,8 +202,9 @@ class ConverterTests {
         @Test
         void testNonBooleanThrows() {
             var wrongValue = Value.newBuilder().setStringValue("").build();
+            var converter = new Converter(log);
             assertThatThrownBy(
-                    () -> Converter.convertValue("BooleanConverterTests", wrongValue, Boolean.class)
+                    () -> converter.convertValue("BooleanConverterTests", wrongValue, Boolean.class)
             ).isInstanceOf(UnsupportedOperationException.class)
                     .hasMessageContaining("Expected 'java.lang.Boolean' but got 'java.lang.String' while deserializing");
         }
@@ -209,8 +216,9 @@ class ConverterTests {
                 .setOptions(new TestOptions(true))
                 .setMockGlobalInstance();
 
+            var converter = new Converter(log);
             var nullValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", nullValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isFalse();
@@ -224,8 +232,9 @@ class ConverterTests {
                 .setOptions(new TestOptions(false))
                 .setMockGlobalInstance();
 
+            var converter = new Converter(log);
             var nullValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", nullValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isFalse();
@@ -234,8 +243,9 @@ class ConverterTests {
 
         @Test
         void testUnknownProducesFalseUnknown() {
+            var converter = new Converter(log);
             var unknownValue = Value.newBuilder().setStringValue(Constants.UnknownValue).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", unknownValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isFalse();
@@ -244,9 +254,10 @@ class ConverterTests {
 
         @Test
         void testEmptyStringThrows() {
+            var converter = new Converter(log);
             var wrongValue = Value.newBuilder().setStringValue("").build();
             assertThatThrownBy(
-                    () -> Converter.convertValue("BooleanConverterTests", wrongValue, Boolean.class)
+                    () -> converter.convertValue("BooleanConverterTests", wrongValue, Boolean.class)
             ).isInstanceOf(UnsupportedOperationException.class)
                     .hasMessageContaining("Expected 'java.lang.Boolean' but got 'java.lang.String' while deserializing");
 
@@ -254,8 +265,9 @@ class ConverterTests {
 
         @Test
         void testOptionalTrueWrapped() {
+            var converter = new Converter(log);
             var trueValue = Value.newBuilder().setBoolValue(true).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", trueValue, TypeShape.optional(Boolean.class)
             );
             assertThat(data.getValueNullable()).isNotNull().isPresent().contains(true);
@@ -264,8 +276,9 @@ class ConverterTests {
 
         @Test
         void testOptionalTrueUnwrapped() {
+            var converter = new Converter(log);
             var trueValue = Value.newBuilder().setBoolValue(true).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", trueValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isTrue();
@@ -274,8 +287,9 @@ class ConverterTests {
 
         @Test
         void testOptionalFalseWrapped() {
+            var converter = new Converter(log);
             var trueValue = Value.newBuilder().setBoolValue(false).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", trueValue, TypeShape.optional(Boolean.class)
             );
             assertThat(data.getValueNullable()).isNotNull().isPresent().contains(false);
@@ -284,8 +298,9 @@ class ConverterTests {
 
         @Test
         void testOptionalFalseUnwrapped() {
+            var converter = new Converter(log);
             var trueValue = Value.newBuilder().setBoolValue(false).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", trueValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isNotNull().isFalse();
@@ -294,8 +309,9 @@ class ConverterTests {
 
         @Test
         void testNullToOptionalEmpty() {
+            var converter = new Converter(log);
             var nullValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", nullValue, TypeShape.optional(Boolean.class)
             );
             assertThat(data.getValueNullable()).isNotNull().isEmpty();
@@ -304,8 +320,9 @@ class ConverterTests {
 
         @Test
         void testNullToNullUnwrapped() {
+            var converter = new Converter(log);
             var nullValue = Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "BooleanConverterTests", nullValue, Boolean.class
             );
             assertThat(data.getValueNullable()).isFalse();
@@ -319,8 +336,9 @@ class ConverterTests {
         @ParameterizedTest
         @EnumSource(ContainerSize.class)
         void testCustomIntEnum(ContainerSize input) {
+            var converter = new Converter(log);
             serializeToValueAsync(input)
-                    .thenApply(value -> Converter.convertValue("EnumConverterTests", value, ContainerSize.class))
+                    .thenApply(value -> converter.convertValue("EnumConverterTests", value, ContainerSize.class))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable()).isNotNull();
                         assertThat(input.asDouble()).isEqualTo(data.getValueNullable().asDouble());
@@ -331,8 +349,9 @@ class ConverterTests {
         @ParameterizedTest
         @EnumSource(JarSize.class)
         void testStandardIntEnum(JarSize input) {
+            var converter = new Converter(log);
             serializeToValueAsync(input)
-                    .thenApply(value -> Converter.convertValue("EnumConverterTests", value, JarSize.class))
+                    .thenApply(value -> converter.convertValue("EnumConverterTests", value, JarSize.class))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable()).isNotNull();
                         assertThat(input.asDouble()).isEqualTo(data.getValueNullable().asDouble());
@@ -343,8 +362,9 @@ class ConverterTests {
         @ParameterizedTest
         @EnumSource(ContainerColor.class)
         void testCustomStringEnum(ContainerColor input) {
+            var converter = new Converter(log);
             serializeToValueAsync(input)
-                    .thenApply(value -> Converter.convertValue("EnumConverterTests", value, ContainerColor.class))
+                    .thenApply(value -> converter.convertValue("EnumConverterTests", value, ContainerColor.class))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable()).isNotNull();
                         assertThat(input.getValue()).isEqualTo(data.getValueNullable().getValue());
@@ -355,8 +375,9 @@ class ConverterTests {
         @ParameterizedTest
         @EnumSource(ContainerBrightness.class)
         void testCustomDoubleEnum(ContainerBrightness input) {
+            var converter = new Converter(log);
             serializeToValueAsync(input)
-                    .thenApply(value -> Converter.convertValue("EnumConverterTests", value, ContainerBrightness.class))
+                    .thenApply(value -> converter.convertValue("EnumConverterTests", value, ContainerBrightness.class))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable()).isNotNull();
                         assertThat(input.getValue()).isEqualTo(data.getValueNullable().getValue());
@@ -377,7 +398,8 @@ class ConverterTests {
         @ParameterizedTest
         @MethodSource("io.pulumi.serialization.internal.ConverterTests#testConvertingNonconvertibleValuesThrows")
         void testConvertingNonconvertibleValuesThrows(Class<?> targetType, Value value) {
-            assertThatThrownBy(() -> Converter.convertValue("EnumConverterTests", value, targetType))
+            var converter = new Converter(log);
+            assertThatThrownBy(() -> converter.convertValue("EnumConverterTests", value, targetType))
                     .isInstanceOf(UnsupportedOperationException.class)
                     .hasMessageContaining("Expected value that match any of enum");
         }
@@ -388,7 +410,8 @@ class ConverterTests {
 
         @Test
         void testLeft() {
-            var data = Converter.convertValue(
+            var converter = new Converter(log);
+            var data = converter.convertValue(
                     "EitherConverterTests", Value.newBuilder().setNumberValue(1).build(), TypeShape.either(Integer.class, String.class));
             assertThat(data.isKnown()).isTrue();
             assertThat(data.getValueNullable()).isNotNull();
@@ -398,8 +421,9 @@ class ConverterTests {
 
         @Test
         void testRight() {
+            var converter = new Converter(log);
             var value = Value.newBuilder().setStringValue("foo").build();
-            var data = Converter.convertValue(
+            var data = converter.convertValue(
                     "EitherConverterTests", value, TypeShape.either(Integer.class, String.class));
             assertThat(data.isKnown()).isTrue();
             assertThat(data.getValueNullable()).isNotNull();
@@ -413,6 +437,7 @@ class ConverterTests {
 
         @Test
         public void ignoreInternalProperty() {
+            var converter = new Converter(log);
             var value = Value.newBuilder().setStructValue(
                     Struct.newBuilder()
                             .putFields("a", Value.newBuilder().setStringValue("b").build())
@@ -423,7 +448,7 @@ class ConverterTests {
                     .addParameter(String.class)
                     .addParameter(String.class)
                     .build();
-            var data = Converter.convertValue("InternalPropertyTests", value, shape);
+            var data = converter.convertValue("InternalPropertyTests", value, shape);
             assertThat(data.isKnown()).isTrue();
             //noinspection unchecked
             assertThat(data.getValueNullable()).isNotNull();
@@ -443,10 +468,11 @@ class ConverterTests {
         @ParameterizedTest
         @MethodSource("io.pulumi.serialization.internal.ConverterTests#testJsons")
         void testJsons(String json, String expected) {
+            var converter = new Converter(log);
             var element = gson.fromJson(json, JsonElement.class);
             serializeToValueAsync(element)
                     .thenAccept(serialized -> {
-                        var converted = Converter.convertValue("JsonConverterTests", serialized, JsonElement.class);
+                        var converted = converter.convertValue("JsonConverterTests", serialized, JsonElement.class);
                         assertThat(converted.getValueNullable()).isNotNull();
                         assertThat(converted.getValueNullable().toString()).isEqualTo(expected);
                     })
@@ -459,9 +485,10 @@ class ConverterTests {
 
         @Test
         void testEmptyList() {
+            var converter = new Converter(log);
             List<Boolean> emptyList = List.of();
             serializeToValueAsync(emptyList)
-                    .thenApply(value -> Converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
+                    .thenApply(value -> converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable()).isNotNull().isEmpty();
                         assertThat(data.isKnown()).isTrue();
@@ -470,9 +497,10 @@ class ConverterTests {
 
         @Test
         void testListWithElement() {
+            var converter = new Converter(log);
             var listWithElement = List.of(true);
             serializeToValueAsync(listWithElement)
-                    .thenApply(value -> Converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
+                    .thenApply(value -> converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable())
                                 .isNotNull()
@@ -484,9 +512,10 @@ class ConverterTests {
 
         @Test
         void testSecretListWithElement() {
+            var converter = new Converter(log);
             var secretListWithElement = Output.ofSecret(List.of(true));
             serializeToValueAsync(secretListWithElement)
-                    .thenApply(value -> Converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
+                    .thenApply(value -> converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable())
                                 .isNotNull()
@@ -500,9 +529,10 @@ class ConverterTests {
 
         @Test
         void testListWithSecretElement() {
+            var converter = new Converter(log);
             var listWithSecretElement = List.of(Output.ofSecret(true));
             serializeToValueAsync(listWithSecretElement)
-                    .thenApply(value -> Converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
+                    .thenApply(value -> converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable())
                                 .isNotNull()
@@ -515,9 +545,10 @@ class ConverterTests {
 
         @Test
         void testListWithUnknownElement() {
+            var converter = new Converter(log);
             var listWithUnknownElement = List.of(InputOutputTests.unknown(true));
             serializeToValueAsync(listWithUnknownElement)
-                    .thenApply(value -> Converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
+                    .thenApply(value -> converter.convertValue("ListConverterTests", value, TypeShape.list(Boolean.class)))
                     .thenAccept(data -> {
                         assertThat(data.getValueNullable())
                                 .isNotNull()
@@ -534,6 +565,7 @@ class ConverterTests {
 
         @Test
         void testSimpleCase() {
+            var converter = new Converter(log);
             var value = Value.newBuilder()
                     .setStructValue(
                             Struct.newBuilder()
@@ -553,7 +585,7 @@ class ConverterTests {
                                             ).build()
                                     ).build()
                     ).build();
-            var data = Converter.convertValue("", value, RecursiveType.class);
+            var data = converter.convertValue("", value, RecursiveType.class);
 
             assertThat(data.isKnown()).isTrue();
             assertThat(data.getValueNullable()).isNotNull();


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

- make the Converter be permissive of a null value in @OutputCustomType annotated constructor parameter without @Nullable annotation

Fixes #164

Coincidentally, this also makes changes that are prerequisite to port this change: https://github.com/pulumi/pulumi/pull/8286

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
