### PR TITLE
Add `RemoveStackOptions` to Automation API

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
 
+* Add `RemoveStackOptions` to Automation API
+
 ### Bug Fixes
 
 * Fix generated 'plan' argument of 'preview' command

--- a/sdk/java/pulumi/src/main/java/com/pulumi/automation/StackRemoveOptions.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/automation/StackRemoveOptions.java
@@ -1,0 +1,113 @@
+// Copyright 2025, Pulumi Corporation
+
+package com.pulumi.automation;
+
+/**
+ * Options for removing stacks.
+ */
+public final class StackRemoveOptions {
+    /**
+     * An empty set of options.
+     */
+    public static final StackRemoveOptions Empty = StackRemoveOptions.builder().build();
+
+    private final boolean force;
+    private final boolean preserveConfig;
+    private final boolean removeBackups;
+
+    private StackRemoveOptions(Builder builder) {
+        this.force = builder.force;
+        this.preserveConfig = builder.preserveConfig;
+        this.removeBackups = builder.removeBackups;
+    }
+
+    /**
+     * Returns a new builder for {@link StackRemoveOptions}.
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Forces deletion of the stack, leaving behind any resources managed by the stack
+     *
+     * @return whether to force deletion
+     */
+    public boolean force() {
+        return force;
+    }
+
+    /**
+     * Do not delete the corresponding {@code Pulumi.<stack-name>.yaml} configuration file for the stack
+     *
+     * @return whether to preserve the configuration
+     */
+    public boolean preserveConfig() {
+        return preserveConfig;
+    }
+
+    /**
+     * Remove backups of the stack, if using the DIY backend
+     *
+     * @return whether to remove backups
+     */
+    public boolean removeBackups() {
+        return removeBackups;
+    }
+
+    /**
+     * Builder for {@link StackRemoveOptions}.
+     */
+    public static class Builder {
+        private boolean force;
+        private boolean preserveConfig;
+        private boolean removeBackups;
+
+        private Builder() {
+        }
+
+        /**
+         * Forces deletion of the stack, leaving behind any resources managed by the stack
+         *
+         * @param force whether to force deletion
+         * @return the builder
+         */
+        public Builder force(boolean force) {
+            this.force = force;
+            return this;
+        }
+
+        /**
+         * Do not delete the corresponding {@code Pulumi.<stack-name>.yaml} configuration file for the stack
+         *
+         * @param preserveConfig whether to preserve the configuration
+         * @return the builder
+         */
+        public Builder preserveConfig(boolean preserveConfig) {
+            this.preserveConfig = preserveConfig;
+            return this;
+        }
+
+        /**
+         * Remove backups of the stack, if using the DIY backend
+         *
+         * @param removeBackups whether to remove backups
+         * @return the builder
+         */
+        public Builder removeBackups(boolean removeBackups) {
+            this.removeBackups = removeBackups;
+            return this;
+        }
+
+        /**
+         * Builds the {@link StackRemoveOptions}.
+         *
+         * @return the options
+         */
+        public StackRemoveOptions build() {
+            return new StackRemoveOptions(this);
+        }
+    }
+}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/automation/Workspace.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/automation/Workspace.java
@@ -412,6 +412,21 @@ public abstract class Workspace implements AutoCloseable {
     public abstract void removeStack(String stackName) throws AutomationException;
 
     /**
+     * Deletes the stack and all associated configuration and history.
+     *
+     * @param stackName the stack to remove
+     * @param options   options for removing the stack
+     * @throws AutomationException if there was an issue removing the stack
+     */
+    public void removeStack(String stackName, StackRemoveOptions options) throws AutomationException {
+        if (options != null && options != StackRemoveOptions.Empty) {
+            throw new UnsupportedOperationException(
+                "StackRemoveOptions are not supported in this workspace implementation");
+        }
+        removeStack(stackName);
+    }
+
+    /**
      * Returns all stacks created under the current project.
      * <p>
      * This queries underlying backend and may return stacks not present in the


### PR DESCRIPTION
This change adds `RemoveStackOptions` to Automation API, with support for `force`, `preserveConfig`, and `removeBackups` options. `removeBackups` requires v3.188.0 or later of the Pulumi CLI.

Part of https://github.com/pulumi/pulumi/issues/9474
Follow-up of https://github.com/pulumi/pulumi/pull/20203

This is blocked on the v3.188.0 release of the CLI. The `removeBackups` test will fail until that version of the CLI is released.