### PR TITLE
Fix inherited input properties missing from Java component schema

### DIFF
--- a/.changes/unreleased/bug-fixes-2129.yaml
+++ b/.changes/unreleased/bug-fixes-2129.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix inherited input properties missing from component schema when args class inherits from a base class
+time: 2026-04-07T13:00:00Z
+custom:
+  PR: 2129
+component: sdk

--- a/sdk/java/pulumi/src/main/java/com/pulumi/provider/internal/infer/ComponentAnalyzer.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/provider/internal/infer/ComponentAnalyzer.java
@@ -166,7 +166,9 @@ public final class ComponentAnalyzer {
         Map<String, PropertySpec> properties = new HashMap<>();
         Set<String> required = new TreeSet<>();
 
-        Arrays.stream(type.getDeclaredFields())
+        // Walk the class hierarchy to include inherited fields, filtering
+        // out Pulumi SDK base classes.
+        getAllFields(type).stream()
                 .forEach(field -> {
                     String schemaName = getSchemaPropertyName(field);
                     analyzeProperty(field).ifPresent(propertyDef -> {
@@ -178,6 +180,21 @@ public final class ComponentAnalyzer {
                 });
 
         return new TypeAnalysis(properties, required);
+    }
+
+    private static final Set<Class<?>> PULUMI_BASE_TYPES = Set.of(
+        ResourceArgs.class, ComponentResource.class, CustomResource.class
+    );
+
+    private static List<java.lang.reflect.Field> getAllFields(Class<?> type) {
+        var fields = new java.util.ArrayList<java.lang.reflect.Field>();
+        for (Class<?> c = type; c != null && c != Object.class; c = c.getSuperclass()) {
+            if (PULUMI_BASE_TYPES.contains(c)) {
+                break;
+            }
+            fields.addAll(Arrays.asList(c.getDeclaredFields()));
+        }
+        return fields;
     }
 
     private TypeAnalysis analyzeOutputsWithRequired(Class<?> type) {

--- a/sdk/java/pulumi/src/test/java/com/pulumi/provider/internal/infer/ComponentAnalyzerTests.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/provider/internal/infer/ComponentAnalyzerTests.java
@@ -838,13 +838,23 @@ public class ComponentAnalyzerTests {
     @Test
     void testInheritedInputProperties() {
         var schema = ComponentAnalyzer.generateSchema(metadata, InheritedComponent.class);
-        var resource = schema.getResources().get("my-component:index:InheritedComponent");
 
-        assertNotNull(resource);
-        // Both base and derived input properties should be present
-        assertTrue(resource.getInputProperties().containsKey("baseProp"),
-            "baseProp from base class should be present");
-        assertTrue(resource.getInputProperties().containsKey("childProp"),
-            "childProp from derived class should be present");
+        var expected = createBasePackageSpec()
+            .setResources(Map.of(
+                "my-component:index:InheritedComponent",
+                new ResourceSpec(
+                    Map.of(
+                        "baseProp", PropertySpec.ofBuiltin("string", true),
+                        "childProp", PropertySpec.ofBuiltin("string", true)
+                    ),
+                    Set.of(),
+                    Map.of(
+                        "result", PropertySpec.ofBuiltin("string")
+                    ),
+                    Set.of()
+                )
+            ));
+
+        assertEquals(expected, schema);
     }
 }

--- a/sdk/java/pulumi/src/test/java/com/pulumi/provider/internal/infer/ComponentAnalyzerTests.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/provider/internal/infer/ComponentAnalyzerTests.java
@@ -813,4 +813,38 @@ public class ComponentAnalyzerTests {
 
         assertEquals(expected, schema);
     }
+
+    // --- Inherited input properties test ---
+
+    public static class BaseComponentArgs extends ResourceArgs {
+        @Import(name = "baseProp")
+        private String baseProp;
+    }
+
+    public static class DerivedComponentArgs extends BaseComponentArgs {
+        @Import(name = "childProp")
+        private String childProp;
+    }
+
+    public static class InheritedComponent extends ComponentResource {
+        @Export(name = "result")
+        private Output<String> result;
+
+        public InheritedComponent(DerivedComponentArgs args) {
+            super("my-component:index:InheritedComponent", "test");
+        }
+    }
+
+    @Test
+    void testInheritedInputProperties() {
+        var schema = ComponentAnalyzer.generateSchema(metadata, InheritedComponent.class);
+        var resource = schema.getResources().get("my-component:index:InheritedComponent");
+
+        assertNotNull(resource);
+        // Both base and derived input properties should be present
+        assertTrue(resource.getInputProperties().containsKey("baseProp"),
+            "baseProp from base class should be present");
+        assertTrue(resource.getInputProperties().containsKey("childProp"),
+            "childProp from derived class should be present");
+    }
 }


### PR DESCRIPTION
## Summary

- When an args class inherits from a base class, only fields declared on the immediate class were included in the generated schema - inherited properties were missing
- Root cause: `type.getDeclaredFields()` in `analyzeType` only returns fields declared directly on the class, not inherited ones
- Added `getAllFields()` helper that walks the class hierarchy, stopping at Pulumi SDK base classes (`ResourceArgs`, `ComponentResource`, `CustomResource`)
- Related fixes: pulumi/pulumi-dotnet#930 (C#), pulumi/pulumi#22446 (TypeScript), pulumi/pulumi#22484 (Python)

**Note:** Outputs still use `getDeclaredFields` (direct only). Switching outputs to `getAllFields` would require similar base-class filtering - left as a separate fix.

## Test plan

- [x] Added `testInheritedInputProperties` test with `BaseComponentArgs`/`DerivedComponentArgs` inheritance
- [x] All 18 ComponentAnalyzer tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)