### PR TITLE
Upgrade pulumi/pulumi to v3.230.0

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,2 +1,4 @@
 // This is a phony module to prevent sdk from being included in the go mod download
-module  phony
+module phony
+
+go 1.25.9


### PR DESCRIPTION
## Summary

- Upgrade `github.com/pulumi/pulumi/pkg/v3` and `github.com/pulumi/pulumi/sdk/v3` from v3.229.0 to v3.230.0
- Skip 2 new conformance tests that fail due to missing Java SDK support

## Skipped Tests

| Test | Reason | PR |
|------|--------|----|
| `l1-builtin-file` | cannot find symbol `Base64` and `computeFileBase64Sha256` | pulumi/pulumi#22440 |
| `l3-range-ref` | `KeyedValue.of()` expects `Iterable`, got `String` | pulumi/pulumi#22498 |

## Test plan

- [x] `make lint` passes
- [x] `go test . -run TestLanguage` passes (all non-skipped tests)