### PR TITLE
Clarify docs on `remote` parameter of ComponentResource

### DIFF
--- a/.changes/unreleased/Improvements-clarify-remote-param-docs.yaml
+++ b/.changes/unreleased/Improvements-clarify-remote-param-docs.yaml
@@ -1,0 +1,4 @@
+component: sdk
+kind: Improvements
+body: Clarify docs on the `remote` parameter of `ComponentResource` / `Resource` constructors.
+time: 2026-04-14T00:00:00.000000Z

--- a/sdk/java/pulumi/src/main/java/com/pulumi/resources/ComponentResource.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/resources/ComponentResource.java
@@ -45,7 +45,11 @@ public class ComponentResource extends Resource {
      * @param type    The type of the resource
      * @param name    The unique name of the resource
      * @param options A bag of options that control this resource's behavior
-     * @param remote  True if this is a remote component resource
+     * @param remote  This parameter is intended for use by code-generated component SDKs;
+     *                end users authoring their own {@link ComponentResource} subclasses should
+     *                leave this at its default ({@code false}). When {@code true}, the component's
+     *                children are constructed by the engine rather than in this process, and the
+     *                constructor skips local child registration accordingly.
      */
     public ComponentResource(String type, String name, @Nullable ComponentResourceOptions options, boolean remote) {
         this(type, name, ResourceArgs.Empty, options, remote, null);
@@ -69,7 +73,11 @@ public class ComponentResource extends Resource {
      * @param type    The type of the resource
      * @param name    The unique name of the resource
      * @param args    The arguments to use to populate the new resource
-     * @param remote  True if this is a remote component resource
+     * @param remote  This parameter is intended for use by code-generated component SDKs;
+     *                end users authoring their own {@link ComponentResource} subclasses should
+     *                leave this at its default ({@code false}). When {@code true}, the component's
+     *                children are constructed by the engine rather than in this process, and the
+     *                constructor skips local child registration accordingly.
      * @param options A bag of options that control this resource's behavior
      */
     public ComponentResource(String type, String name, @Nullable ResourceArgs args, @Nullable ComponentResourceOptions options, boolean remote) {
@@ -88,7 +96,11 @@ public class ComponentResource extends Resource {
      * @param name       The unique name of the resource
      * @param args       The arguments to use to populate the new resource
      * @param options    A bag of options that control this resource's behavior
-     * @param remote     True if this is a remote component resource
+     * @param remote     This parameter is intended for use by code-generated component SDKs;
+     *                   end users authoring their own {@link ComponentResource} subclasses should
+     *                   leave this at its default ({@code false}). When {@code true}, the component's
+     *                   children are constructed by the engine rather than in this process, and the
+     *                   constructor skips local child registration accordingly.
      * @param packageRef The package reference to use for this resource
      */
     public ComponentResource(String type, String name, @Nullable ResourceArgs args, @Nullable ComponentResourceOptions options, boolean remote, CompletableFuture<String> packageRef) {

--- a/sdk/java/pulumi/src/main/java/com/pulumi/resources/Resource.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/resources/Resource.java
@@ -98,7 +98,11 @@ public abstract class Resource {
      * @param custom     true to indicate that this is a custom resource, managed by a plugin
      * @param args       the arguments to use to populate the new resource
      * @param options    a bag of options that control this resource's behavior
-     * @param remote     true if this is a remote component resource
+     * @param remote     This parameter is intended for use by code-generated component SDKs;
+     *                   end users authoring their own {@link ComponentResource} subclasses should
+     *                   leave this at its default ({@code false}). When {@code true}, the component's
+     *                   children are constructed by the engine rather than in this process, and the
+     *                   constructor skips local child registration accordingly.
      * @param dependency true if this is a synthetic resource used internally for dependency tracking
      * @param packageRef the package reference to use if this resource belongs to a parameterized provider
      */


### PR DESCRIPTION
## Summary
- The `remote` parameter on `Resource` / `ComponentResource` constructors in the Java SDK is intended for use by code-generated component SDKs, not by end users.
- Previous docs ("True if this is a remote component resource") were circular and gave no guidance. Expanded to tell end users to leave the default and describe what changes when it is `true`.

Mirrors pulumi/pulumi#22603 for the Java SDK. Relates to pulumi/pulumi#21377.

## Test plan
- [x] Docs-only change; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)