### PR TITLE
Pass PULUMI_BOT_TOKEN to checkout in release workflow

### DIFF
--- a/.github/workflows/release-java-provider.yml
+++ b/.github/workflows/release-java-provider.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags


### PR DESCRIPTION
## Summary

- `release-java-provider.yml` pushes the `sdk/v*` tag from its "Push additional tags" step, which is supposed to trigger `release-java-sdk-to-maven-central.yml`.
- But the `actions/checkout@v5` step wasn't receiving `PULUMI_BOT_TOKEN`, so the `origin` remote was configured with the ephemeral `GITHUB_TOKEN`. Tag pushes authenticated with `GITHUB_TOKEN` do not trigger downstream workflows (GitHub Actions security policy).
- Result: no run of `release-java-sdk-to-maven-central.yml` since v1.21.3 — v1.22.0 and v1.23.0 are missing from Maven Central (confirmed via `repo1.maven.org/maven2/com/pulumi/pulumi/maven-metadata.xml`).

## Test plan

- [ ] Merge this PR (draft until ready) — it only changes the workflow file, so nothing fires on merge.
- [ ] Next changelog-driven release should push `sdk/v*` with the PAT and trigger `release-java-sdk-to-maven-central.yml`.
- [ ] Publish the missing v1.22.0 and v1.23.0 artifacts to Maven Central separately (likely via a one-off `workflow_dispatch` on that workflow, or a manual `gradle publishToSonatype` run against those tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)