### PR TITLE
ci: skip tests for changelog-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
## Summary

- Add `predicate-quantifier: 'every'` to the `dorny/paths-filter` step in `.github/workflows/ci.yml` that decides whether the full test matrix should run.
- Without this, the negation patterns (`!CHANGELOG.md`, `!.changes/**`) had no effect on changelog-only PRs, so tests ran anyway. #2164 was an example: a one-line CHANGELOG edit triggered prerequisites, java-sdk-tests, etc.

## Why this works

`dorny/paths-filter` defaults to `predicate-quantifier: 'some'`, meaning a file matches a filter if it satisfies *any* one pattern. With `['**', '!CHANGELOG.md', '!.changes/**']`, `CHANGELOG.md` matches `**` and the filter returns true regardless of the negations. Setting the quantifier to `every` requires *all* patterns to hold, so the negations actually exclude changelog files.

Docs: <https://github.com/dorny/paths-filter#predicate-quantifier>

## Test plan

- [ ] This PR itself: it changes `.github/workflows/ci.yml` (a code path), so `should-test` should return true and the full test matrix should run — confirming we did not over-skip.
- [ ] Follow-up sanity check on the next CHANGELOG-only PR: `should-test` should set `run-tests=false` and the heavy jobs should be skipped.