### PR TITLE
Fix `l1-builtin-base64`

### DIFF
--- a/.changes/unreleased/Improvements-l1-builtin-base64.yaml
+++ b/.changes/unreleased/Improvements-l1-builtin-base64.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Implement the PCL `fromBase64` and `toBase64` builtins in the Java program codegen
+time: 2026-05-08T00:00:00Z
+custom:
+  PR: 0
+component: codegen

--- a/pkg/cmd/pulumi-language-java/language_test.go
+++ b/pkg/cmd/pulumi-language-java/language_test.go
@@ -211,7 +211,6 @@ var expectedFailures = map[string]string{
 	"provider-replacement-trigger-component": "https://github.com/pulumi/pulumi-java/issues/2007",
 	"provider-depends-on-component":          "https://github.com/pulumi/pulumi-java/issues/2023",
 	"provider-ignore-changes-component":      "https://github.com/pulumi/pulumi-java/issues/2024",
-	"l1-builtin-base64":                      "TODO: call fromBase64/toBase64 not implemented",
 	"l1-config-secret":                       "compilation error: applyValue called on plain String",
 	"l1-builtin-object":                      "compilation error: illegal start of expression",
 	"l2-builtin-object":                      "compilation error: illegal start of expression",

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-base64/Pulumi.yaml
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-base64/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-base64
+runtime: java

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-base64/pom.xml
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-base64/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+		<project xmlns="http://maven.apache.org/POM/4.0.0"
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			<modelVersion>4.0.0</modelVersion>
+
+			<groupId>com.pulumi</groupId>
+			<artifactId>l1-builtin-base64</artifactId>
+			<version>1.0-SNAPSHOT</version>
+
+			<properties>
+				<encoding>UTF-8</encoding>
+				<maven.compiler.source>11</maven.compiler.source>
+				<maven.compiler.target>11</maven.compiler.target>
+				<maven.compiler.release>11</maven.compiler.release>
+				<mainClass>generated_program.App</mainClass>
+				<mainArgs/>
+			</properties>
+			
+			<repositories>
+				<repository>
+					<id>repository-0</id>
+					<url>REPOSITORY</url>
+				</repository>
+			</repositories>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.pulumi</groupId>
+					<artifactId>pulumi</artifactId>
+					<version>CORE.VERSION</version>
+				</dependency>
+				
+			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>3.2.2</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<addClasspath>true</addClasspath>
+									<mainClass>${mainClass}</mainClass>
+								</manifest>
+							</archive>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>3.4.2</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<addClasspath>true</addClasspath>
+									<mainClass>${mainClass}</mainClass>
+								</manifest>
+							</archive>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>make-my-jar-with-dependencies</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>3.1.0</version>
+						<configuration>
+							<mainClass>${mainClass}</mainClass>
+							<commandlineArgs>${mainArgs}</commandlineArgs>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-wrapper-plugin</artifactId>
+						<version>3.1.1</version>
+						<configuration>
+							<mavenVersion>3.8.5</mavenVersion>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</project>

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-base64/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-base64/src/main/java/generated_program/App.java
@@ -1,0 +1,28 @@
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import java.util.Base64;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        final var config = ctx.config();
+        final var input = config.require("input");
+        final var bytes = new String(Base64.getDecoder().decode(input), StandardCharsets.UTF_8);
+
+        ctx.export("data", bytes);
+        ctx.export("roundtrip", Base64.getEncoder().encodeToString(bytes.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -965,6 +965,22 @@ func (g *generator) genPreamble(w io.Writer, nodes []pcl.Node) {
 		g.genImport(w, "com.pulumi.codegen.internal.Strings")
 	}
 
+	if containsFunctionCall("toBase64", nodes) ||
+		containsFunctionCall("fromBase64", nodes) ||
+		containsFunctionCall("base64encode", nodes) ||
+		containsFunctionCall("base64decode", nodes) ||
+		containsFunctionCall("filebase64", nodes) {
+		g.genImport(w, "java.util.Base64")
+	}
+
+	if containsFunctionCall("toBase64", nodes) ||
+		containsFunctionCall("fromBase64", nodes) ||
+		containsFunctionCall("base64encode", nodes) ||
+		containsFunctionCall("base64decode", nodes) ||
+		containsFunctionCall("file", nodes) {
+		g.genImport(w, "java.nio.charset.StandardCharsets")
+	}
+
 	g.genResourceOptionsImports(w, nodes)
 
 	g.genImport(w, "java.util.ArrayList")

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -448,9 +448,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "Arrays.asList(%.20v.split(%v))", expr.Args[1], expr.Args[0])
 	case "mimeType":
 		g.Fgenf(w, "Files.probeContentType(%v)", expr.Args[0])
-	case "base64encode":
+	case "base64encode", "toBase64":
 		g.Fgenf(w, "Base64.getEncoder().encodeToString(%v.getBytes(StandardCharsets.UTF_8))", expr.Args[0])
-	case "base64decode":
+	case "base64decode", "fromBase64":
 		g.Fgenf(w, "new String(Base64.getDecoder().decode(%v), StandardCharsets.UTF_8)", expr.Args[0])
 	case "toJSON":
 		// Assumes SerializeJson is part of the SDK


### PR DESCRIPTION
## Summary

- Implements the PCL `fromBase64` and `toBase64` builtins in the Java program codegen by reusing the existing `Base64` encode/decode emit paths.
- Conditionally imports `java.util.Base64` and `java.nio.charset.StandardCharsets` when the program calls a function that needs them, fixing a latent bug where `base64encode`, `base64decode`, `file`, and `filebase64` emitted references to those classes without importing them.
- Removes `l1-builtin-base64` from `expectedFailures` and adds the generated program snapshot.

## Test plan

- [x] `mise exec -- go test -run "TestLanguage/l1-builtin-base64" ./cmd/pulumi-language-java/`
- [x] `mise exec -- make lint`
- [x] `mise exec -- go test ./codegen/java/...`