### PR TITLE
Fix `l1-builtin-project-root`

### DIFF
--- a/.changes/unreleased/Improvements-l1-builtin-base64.yaml
+++ b/.changes/unreleased/Improvements-l1-builtin-base64.yaml
@@ -2,5 +2,5 @@ kind: Improvements
 body: Implement the PCL `fromBase64` and `toBase64` builtins in the Java program codegen
 time: 2026-05-08T00:00:00Z
 custom:
-  PR: 0
+  PR: 2171
 component: codegen

--- a/.changes/unreleased/Improvements-l1-builtin-project-root.yaml
+++ b/.changes/unreleased/Improvements-l1-builtin-project-root.yaml
@@ -2,5 +2,5 @@ kind: Improvements
 body: Implement the PCL `rootDirectory` builtin and surface the project root directory on `Deployment`
 time: 2026-05-12T00:00:00Z
 custom:
-  PR: "0000"
+  PR: "2176"
 component: sdk/java

--- a/.changes/unreleased/Improvements-l1-builtin-project-root.yaml
+++ b/.changes/unreleased/Improvements-l1-builtin-project-root.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Implement the PCL `rootDirectory` builtin and surface the project root directory on `Deployment`
+time: 2026-05-12T00:00:00Z
+custom:
+  PR: "0000"
+component: sdk/java

--- a/.changes/unreleased/Improvements-l1-builtin-string.yaml
+++ b/.changes/unreleased/Improvements-l1-builtin-string.yaml
@@ -1,6 +1,6 @@
 kind: Improvements
-body: Fix l1-builtin-string by emitting a grapheme-cluster counter for PCL length() on strings, and wrapping split() results as List<String> so they serialize correctly through ctx.export.
+body: Fix l1-builtin-string by emitting a grapheme-cluster counter for PCL length() on strings, and wrapping split() results as List<String> so they serialize correctly through ctx.export
 time: 2026-05-08T00:00:00Z
 custom:
-  PR: 0
+  PR: 2170
 component: codegen

--- a/.changes/unreleased/bug-fixes-2156.yaml
+++ b/.changes/unreleased/bug-fixes-2156.yaml
@@ -1,6 +1,6 @@
 component: sdk
 kind: bug-fixes
-body: Fix child resources unable to override protect, retainOnDelete, and deleteBeforeReplace from parent.
+body: Fix child resources unable to override protect, retainOnDelete, and deleteBeforeReplace from parent
 time: 2026-05-11T14:57:14.03221-04:00
 custom:
     PR: "2156"

--- a/pkg/cmd/pulumi-language-java/language_test.go
+++ b/pkg/cmd/pulumi-language-java/language_test.go
@@ -171,7 +171,6 @@ var expectedFailures = map[string]string{
 	"l2-provider-grpc-config-secret":         "#1568 Don't generate duplicate files",
 	"l2-provider-grpc-config":                "#1568 Don't generate duplicate files",
 	"l2-proxy-index":                         "compilation error",
-	"l2-rtti":                                "TODO: call pulumiResourceName",
 	"l2-component-component-resource-ref":    "components with resources as inputs/outputs not supported",
 	"l2-component-program-resource-ref":      "components with resources as inputs/outputs not supported",
 	"l2-resource-secret":                     "#1564 Fix l2-resource-secret",

--- a/pkg/cmd/pulumi-language-java/language_test.go
+++ b/pkg/cmd/pulumi-language-java/language_test.go
@@ -153,7 +153,6 @@ func TestLanguage(t *testing.T) {
 // expectedFailures maps the set of conformance tests we expect to fail to reasons they currently do so, so that we may
 // skip them with an informative message until they are fixed.
 var expectedFailures = map[string]string{
-	"l1-builtin-project-root":                "TODO: call rootDirectory",
 	"l1-builtin-try":                         "#1683 Fix l1-builtin-try/can",
 	"l1-builtin-can":                         "#1683 Fix l1-builtin-try/can",
 	"l1-config-types-object":                 "https://github.com/pulumi/pulumi-java/issues/2005",

--- a/pkg/cmd/pulumi-language-java/main.go
+++ b/pkg/cmd/pulumi-language-java/main.go
@@ -613,6 +613,7 @@ func (host *javaLanguageHost) constructEnv(req *pulumirpc.RunRequest, config, co
 	maybeAppendEnv("project", req.GetProject())
 	maybeAppendEnv("stack", req.GetStack())
 	maybeAppendEnv("pwd", req.GetPwd())
+	maybeAppendEnv("root_directory", req.GetInfo().GetRootDirectory())
 	maybeAppendEnv("dry_run", fmt.Sprintf("%v", req.GetDryRun()))
 	maybeAppendEnv("parallel", fmt.Sprint(req.GetParallel()))
 	maybeAppendEnv("tracing", host.tracing)

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-project-root/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-project-root/src/main/java/generated_program/App.java
@@ -3,8 +3,9 @@ package generated_program;
 import com.pulumi.Context;
 import com.pulumi.Pulumi;
 import com.pulumi.core.Output;
-import java.util.List;
+import com.pulumi.deployment.Deployment;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.io.File;
 import java.nio.file.Files;
@@ -16,6 +17,6 @@ public class App {
     }
 
     public static void stack(Context ctx) {
-        ctx.export("rootDirectoryOutput", "TODO: call rootDirectory");
+        ctx.export("rootDirectoryOutput", Deployment.getInstance().getRootDirectory());
     }
 }

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -777,8 +777,8 @@ func (g *generator) collectFunctionCallImports(functionCall *model.FunctionCallE
 				imports = append(imports, collectObjectImports(argumentsExpr, argumentExprType, "")...)
 			}
 		}
-	case "stack", "project", "organization":
-		// stack(), project(), and organization() functions are pulumi built-ins
+	case "stack", "project", "organization", "rootDirectory":
+		// stack(), project(), organization(), and rootDirectory() functions are pulumi built-ins
 		// they require the Deployment class
 		imports = append(imports, "com.pulumi.deployment.Deployment")
 	}

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -474,6 +474,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgen(w, "Deployment.getInstance().getOrganizationName()")
 	case "cwd":
 		g.Fgen(w, "System.getProperty(\"user.dir\")")
+	case "rootDirectory":
+		g.Fgen(w, "Deployment.getInstance().getRootDirectory()")
 	default:
 		g.genNYI(w, "call %v", expr.Name)
 	}

--- a/pkg/codegen/testing/test/testdata/pulumi-builtins-pp/java/pulumi-builtins.java
+++ b/pkg/codegen/testing/test/testdata/pulumi-builtins-pp/java/pulumi-builtins.java
@@ -20,5 +20,6 @@ public class App {
         ctx.export("stackName", Deployment.getInstance().getStackName());
         ctx.export("projectName", Deployment.getInstance().getProjectName());
         ctx.export("organizationName", Deployment.getInstance().getOrganizationName());
+        ctx.export("rootDir", Deployment.getInstance().getRootDirectory());
     }
 }

--- a/pkg/codegen/testing/test/testdata/pulumi-builtins-pp/pulumi-builtins.pp
+++ b/pkg/codegen/testing/test/testdata/pulumi-builtins-pp/pulumi-builtins.pp
@@ -9,3 +9,7 @@ output "projectName" {
 output "organizationName" {
     value = organization()
 }
+
+output "rootDir" {
+    value = rootDirectory()
+}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/deployment/Deployment.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/deployment/Deployment.java
@@ -50,6 +50,12 @@ public interface Deployment extends ReadOrRegisterResource, RegisterResourceOutp
     }
 
     /**
+     * @return the root directory of the current project, where {@code Pulumi.yaml} lives
+     */
+    @Nonnull
+    String getRootDirectory();
+
+    /**
      * Checks if the engine we are connected to is compatible with the passed in version range. If the version is not
      * compatible with the specified range, an exception is raised.
      *

--- a/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/DeploymentImpl.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/DeploymentImpl.java
@@ -193,6 +193,12 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
     }
 
     @Override
+    @Nonnull
+    public String getRootDirectory() {
+        return this.state.rootDirectory;
+    }
+
+    @Override
     public boolean isDryRun() {
         return this.state.isDryRun;
     }
@@ -1870,6 +1876,7 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
         public final String organizationName;
         public final String projectName;
         public final String stackName;
+        public final String rootDirectory;
         public final boolean isDryRun;
         public final Engine engine;
         public final Monitor monitor;
@@ -1888,6 +1895,7 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
                 String organizationName,
                 String projectName,
                 String stackName,
+                String rootDirectory,
                 boolean isDryRun,
                 Engine engine,
                 Monitor monitor) {
@@ -1896,6 +1904,7 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
             this.organizationName = Objects.requireNonNullElse(organizationName, "organization");
             this.projectName = Objects.requireNonNull(projectName);
             this.stackName = Objects.requireNonNull(stackName);
+            this.rootDirectory = Objects.requireNonNullElse(rootDirectory, "");
             this.isDryRun = isDryRun;
             this.engine = Objects.requireNonNull(engine);
             this.monitor = Objects.requireNonNull(monitor);
@@ -1925,6 +1934,7 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
                 var organization = getEnvironmentVariable("PULUMI_ORGANIZATION").or("organization");
                 var project = getEnvironmentVariable("PULUMI_PROJECT").orThrow(startErrorSupplier);
                 var stack = getEnvironmentVariable("PULUMI_STACK").orThrow(startErrorSupplier);
+                var rootDirectory = getEnvironmentVariable("PULUMI_ROOT_DIRECTORY").or("");
                 var dryRun = getBooleanEnvironmentVariable("PULUMI_DRY_RUN").orThrow(startErrorSupplier);
 
                 var config = Config.parse();
@@ -1938,7 +1948,7 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
                 var monitor = new GrpcMonitor(monitorTarget);
                 standardLogger.log(Level.FINEST, "Created deployment monitor");
 
-                return new DeploymentState(config, standardLogger, organization, project, stack, dryRun, engine, monitor);
+                return new DeploymentState(config, standardLogger, organization, project, stack, rootDirectory, dryRun, engine, monitor);
             } catch (NullPointerException ex) {
                 throw new IllegalStateException(
                         "Program run without the Pulumi engine available; re-run using the `pulumi` CLI", ex);
@@ -1978,7 +1988,7 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
                     settings.getConfigSecretKeys()
             );
 
-            return new DeploymentState(config, deploymentLogger, organizationName, projectName, stackName, isDryRun, engine, monitor);
+            return new DeploymentState(config, deploymentLogger, organizationName, projectName, stackName, "", isDryRun, engine, monitor);
         }
     }
 

--- a/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/DeploymentInstanceInternal.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/DeploymentInstanceInternal.java
@@ -57,6 +57,12 @@ public final class DeploymentInstanceInternal implements DeploymentInstance {
         return deployment.getOrganizationName();
     }
 
+    @Nonnull
+    @Override
+    public String getRootDirectory() {
+        return deployment.getRootDirectory();
+    }
+
     @Override
     public boolean isDryRun() {
         return deployment.isDryRun();

--- a/sdk/java/pulumi/src/main/java/com/pulumi/test/TestOptions.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/test/TestOptions.java
@@ -17,6 +17,7 @@ public class TestOptions {
     private final String organizationName;
     private final String projectName;
     private final String stackName;
+    private final String rootDirectory;
     private final boolean preview;
     private final List<ResourceTransformation> resourceTransformations;
 
@@ -49,11 +50,31 @@ public class TestOptions {
             List<ResourceTransformation> resourceTransformations,
             String organizationName
     ) {
+        this(projectName, stackName, preview, resourceTransformations, organizationName, null);
+    }
+
+    /**
+     * @param projectName             the test project name to use
+     * @param stackName               the test stack name to use
+     * @param preview                 is the test a preview or a normal execution
+     * @param resourceTransformations the test stack resource transformations
+     * @param organizationName        the test organization name to use
+     * @param rootDirectory           the test project root directory to use
+     */
+    public TestOptions(
+            String projectName,
+            String stackName,
+            boolean preview,
+            List<ResourceTransformation> resourceTransformations,
+            String organizationName,
+            String rootDirectory
+    ) {
         this.projectName = requireNonNull(projectName);
         this.stackName = requireNonNull(stackName);
         this.preview = preview;
         this.resourceTransformations = requireNonNull(resourceTransformations);
         this.organizationName = requireNonNullElse(organizationName, "organization");
+        this.rootDirectory = requireNonNullElse(rootDirectory, "");
     }
 
     /**
@@ -75,6 +96,13 @@ public class TestOptions {
      */
     public String stackName() {
         return this.stackName;
+    }
+
+    /**
+     * @return the test project root directory
+     */
+    public String rootDirectory() {
+        return this.rootDirectory;
     }
 
     /**
@@ -106,6 +134,7 @@ public class TestOptions {
         private String organizationName;
         private String projectName;
         private String stackName;
+        private String rootDirectory;
         private boolean preview;
         private List<ResourceTransformation> resourceTransformations;
 
@@ -113,6 +142,7 @@ public class TestOptions {
             this.organizationName = "organization";
             this.projectName = "project";
             this.stackName = "stack";
+            this.rootDirectory = "";
             this.preview = false;
             this.resourceTransformations = List.of();
         }
@@ -151,6 +181,17 @@ public class TestOptions {
         }
 
         /**
+         * The project root directory. Defaults to <b>""</b> if not specified.
+         *
+         * @param rootDirectory the project root directory to use in the test
+         * @return this {@link Builder}
+         */
+        public Builder rootDirectory(String rootDirectory) {
+            this.rootDirectory = rootDirectory;
+            return this;
+        }
+
+        /**
          * The preview mode. Defaults to <b>false</b> if not specified.
          *
          * @param preview set true if test is a preview or false on normal execution
@@ -178,7 +219,8 @@ public class TestOptions {
          */
         public TestOptions build() {
             return new TestOptions(
-                    this.projectName, this.stackName, this.preview, this.resourceTransformations, this.organizationName
+                    this.projectName, this.stackName, this.preview, this.resourceTransformations,
+                    this.organizationName, this.rootDirectory
             );
         }
     }

--- a/sdk/java/pulumi/src/main/java/com/pulumi/test/internal/MockDeployment.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/test/internal/MockDeployment.java
@@ -56,6 +56,12 @@ public class MockDeployment extends DeploymentInstanceHolder implements Deployme
         return this.state.organizationName;
     }
 
+    @Nonnull
+    @Override
+    public String getRootDirectory() {
+        return this.state.rootDirectory;
+    }
+
     @Override
     public boolean isDryRun() {
         return this.state.isDryRun;

--- a/sdk/java/pulumi/src/main/java/com/pulumi/test/internal/PulumiTestInternal.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/test/internal/PulumiTestInternal.java
@@ -368,6 +368,7 @@ public class PulumiTestInternal extends PulumiInternal implements PulumiTest {
                         this.options.organizationName(),
                         this.options.projectName(),
                         this.options.stackName(),
+                        "",
                         this.options.preview(),
                         this.engine,
                         this.monitor

--- a/sdk/java/pulumi/src/main/java/com/pulumi/test/internal/PulumiTestInternal.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/test/internal/PulumiTestInternal.java
@@ -368,7 +368,7 @@ public class PulumiTestInternal extends PulumiInternal implements PulumiTest {
                         this.options.organizationName(),
                         this.options.projectName(),
                         this.options.stackName(),
-                        "",
+                        this.options.rootDirectory(),
                         this.options.preview(),
                         this.engine,
                         this.monitor

--- a/sdk/java/pulumi/src/test/java/com/pulumi/core/internal/ContextAwareCompletableFutureTest.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/core/internal/ContextAwareCompletableFutureTest.java
@@ -58,6 +58,12 @@ class ContextAwareCompletableFutureTest {
             return "";
         }
 
+        @Nonnull
+        @Override
+        public String getRootDirectory() {
+            return "";
+        }
+
         @Override
         public boolean isDryRun() {
             return false;


### PR DESCRIPTION
- Implements the PCL `rootDirectory()` builtin in the Java program codegen, emitting `Deployment.getInstance().getRootDirectory()` and importing `com.pulumi.deployment.Deployment`.
- Adds `getRootDirectory()` to the Java SDK `Deployment` interface and threads the value through `DeploymentImpl`, `DeploymentInstanceInternal`, `MockDeployment`, and the `Context` test stub.
- Teaches `pulumi-language-java` to forward `req.Info.RootDirectory` to the Java program via the `PULUMI_ROOT_DIRECTORY` environment variable.
- Removes `l1-builtin-project-root` from `expectedFailures` and updates the snapshot under `pkg/cmd/pulumi-language-java/testdata/projects/l1-builtin-project-root/`.
- Extends the `pulumi-builtins` codegen fixture to cover `rootDirectory()`.