### PR TITLE
Fix release-java-provider workflow duplicate permissions key

### DIFF
--- a/.github/workflows/release-java-provider.yml
+++ b/.github/workflows/release-java-provider.yml
@@ -5,9 +5,6 @@ on:
     paths: [CHANGELOG.md]
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-
 env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi


### PR DESCRIPTION
## Summary

- PR #1784 ("Use ESC secrets") added `permissions: write-all` at the top of `.github/workflows/release-java-provider.yml` without removing the existing `permissions: contents: write` block. YAML rejects duplicate top-level keys, so every run since has been completing in 0s without scheduling any jobs — blocking the v1.27.0 release (see [run 25790182922](https://github.com/pulumi/pulumi-java/actions/runs/25790182922)).
- Removes the redundant block; `write-all` already covers `contents: write`.

## Verification

- `actionlint` parses the file cleanly (only pre-existing shellcheck info-level warnings remain).
- The other two workflows touched by #1784 (`ci.yml`, `command-dispatch.yml`) do not have duplicate keys and have continued running normally.
- `workflow_dispatch` remains declared, so once this merges the v1.27.0 release can be kicked off manually via `gh workflow run release-java-provider.yml`.

## Test plan

- [ ] Merge to `main`.
- [ ] Trigger the workflow via `workflow_dispatch` and confirm the v1.27.0 release publishes.