### PR TITLE
Fix l1-config-types-primitive language test

### DIFF
--- a/.changes/unreleased/Improvements-l1-config-types-primitive.yaml
+++ b/.changes/unreleased/Improvements-l1-config-types-primitive.yaml
@@ -1,5 +1,5 @@
 kind: Improvements
-body: Fix l1-config-types-primitive by dispatching to typed Config accessors based on the PCL config type and implementing the logical-not and negation unary operators
+body: Implement logical-not and negation unary operators correctly
 time: 2026-05-18T00:00:00Z
 custom:
   PR: "2188"

--- a/.changes/unreleased/Improvements-l1-config-types-primitive.yaml
+++ b/.changes/unreleased/Improvements-l1-config-types-primitive.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Fix l1-config-types-primitive by dispatching to typed Config accessors based on the PCL config type and implementing the logical-not and negation unary operators
+time: 2026-05-18T00:00:00Z
+custom:
+  PR: "2188"
+component: codegen

--- a/pkg/cmd/pulumi-language-java/language_test.go
+++ b/pkg/cmd/pulumi-language-java/language_test.go
@@ -156,7 +156,6 @@ var expectedFailures = map[string]string{
 	"l1-builtin-try":                         "#1683 Fix l1-builtin-try/can",
 	"l1-builtin-can":                         "#1683 Fix l1-builtin-try/can",
 	"l1-config-types-object":                 "https://github.com/pulumi/pulumi-java/issues/2005",
-	"l1-config-types-primitive":              "https://github.com/pulumi/pulumi-java/issues/2004",
 	"l1-keyword-overlap":                     "#1681 Fix l1-keyword-overlap",
 	"l1-output-string":                       "#1562 Large string literals are not generated correctly",
 	"l1-proxy-index":                         "compilation error",

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-primitive/Pulumi.yaml
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-primitive/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-config-types-primitive
+runtime: java

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-primitive/pom.xml
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-primitive/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+		<project xmlns="http://maven.apache.org/POM/4.0.0"
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			<modelVersion>4.0.0</modelVersion>
+
+			<groupId>com.pulumi</groupId>
+			<artifactId>l1-config-types-primitive</artifactId>
+			<version>1.0-SNAPSHOT</version>
+
+			<properties>
+				<encoding>UTF-8</encoding>
+				<maven.compiler.source>11</maven.compiler.source>
+				<maven.compiler.target>11</maven.compiler.target>
+				<maven.compiler.release>11</maven.compiler.release>
+				<mainClass>generated_program.App</mainClass>
+				<mainArgs/>
+			</properties>
+			
+			<repositories>
+				<repository>
+					<id>repository-0</id>
+					<url>REPOSITORY</url>
+				</repository>
+			</repositories>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.pulumi</groupId>
+					<artifactId>pulumi</artifactId>
+					<version>CORE.VERSION</version>
+				</dependency>
+				
+			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>3.2.2</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<addClasspath>true</addClasspath>
+									<mainClass>${mainClass}</mainClass>
+								</manifest>
+							</archive>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>3.4.2</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<addClasspath>true</addClasspath>
+									<mainClass>${mainClass}</mainClass>
+								</manifest>
+							</archive>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>make-my-jar-with-dependencies</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>3.1.0</version>
+						<configuration>
+							<mainClass>${mainClass}</mainClass>
+							<commandlineArgs>${mainArgs}</commandlineArgs>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-wrapper-plugin</artifactId>
+						<version>3.1.1</version>
+						<configuration>
+							<mavenVersion>3.8.5</mavenVersion>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</project>

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-primitive/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-primitive/src/main/java/generated_program/App.java
@@ -1,0 +1,37 @@
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        final var config = ctx.config();
+        final var aNumber = config.requireDouble("aNumber");
+        ctx.export("theNumber", aNumber + 1.25);
+        final var optionalNumber = config.getDouble("optionalNumber").orElse(41.5);
+        ctx.export("defaultNumber", optionalNumber + 1.2);
+        final var anInt = config.requireInteger("anInt");
+        ctx.export("theInteger", anInt + 4);
+        final var optionalInt = config.getInteger("optionalInt").orElse(1);
+        ctx.export("defaultInteger", optionalInt + 2);
+        final var aString = config.require("aString");
+        ctx.export("theString", String.format("%s World", aString));
+        final var optionalString = config.get("optionalString").orElse("defaultStringValue");
+        ctx.export("defaultString", optionalString);
+        final var aBool = config.requireBoolean("aBool");
+        ctx.export("theBool", !aBool && true);
+        final var optionalBool = config.getBoolean("optionalBool").orElse(false);
+        ctx.export("defaultBool", optionalBool);
+    }
+}

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1456,19 +1456,31 @@ func (g *generator) genResource(w io.Writer, resource *pcl.Resource) {
 
 func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVariable) {
 	g.genIndent(w)
+
+	configType := model.ResolveOutputs(configVariable.Type())
+	typeSuffix := ""
+	switch configType {
+	case model.BoolType:
+		typeSuffix = "Boolean"
+	case model.IntType:
+		typeSuffix = "Integer"
+	case model.NumberType:
+		typeSuffix = "Double"
+	}
+
+	name := names.MakeValidIdentifier(configVariable.Name())
+	logicalName := configVariable.LogicalName()
+	secret := ""
+	if configVariable.Secret {
+		secret = "Secret"
+	}
+
 	if configVariable.DefaultValue != nil {
-		g.Fgenf(w, "final var %s = config.get(\"%s\").orElse(%v);",
-			names.MakeValidIdentifier(configVariable.Name()),
-			configVariable.Name(),
-			configVariable.DefaultValue)
-	} else if configVariable.Secret {
-		g.Fgenf(w, "final var %s = config.requireSecret(\"%s\");",
-			names.MakeValidIdentifier(configVariable.Name()),
-			configVariable.Name())
+		g.Fgenf(w, "final var %s = config.get%s%s(\"%s\").orElse(%v);",
+			name, secret, typeSuffix, logicalName, configVariable.DefaultValue)
 	} else {
-		g.Fgenf(w, "final var %s = config.require(\"%s\");",
-			names.MakeValidIdentifier(configVariable.Name()),
-			configVariable.Name())
+		g.Fgenf(w, "final var %s = config.require%s%s(\"%s\");",
+			name, secret, typeSuffix, logicalName)
 	}
 	g.genNewline(w)
 }

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -966,6 +966,17 @@ func (g *generator) genNullableTupleElement(w io.Writer, expr model.Expression) 
 	}
 }
 
-func (g *generator) GenUnaryOpExpression(w io.Writer, _ *model.UnaryOpExpression) {
-	g.genNYI(w, "GenUnaryOpExpression") // TODO
+func (g *generator) GenUnaryOpExpression(w io.Writer, expr *model.UnaryOpExpression) {
+	var opstr string
+	switch expr.Operation {
+	case hclsyntax.OpLogicalNot:
+		opstr = "!"
+	case hclsyntax.OpNegate:
+		opstr = "-"
+	default:
+		g.genNYI(w, "GenUnaryOpExpression")
+		return
+	}
+	precedence := g.GetPrecedence(expr)
+	g.Fgenf(w, "%[2]v%.[1]*[3]v", precedence, opstr, expr.Operand)
 }

--- a/sdk/java/pulumi/src/main/java/com/pulumi/Config.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/Config.java
@@ -242,6 +242,22 @@ public class Config {
     }
 
     /**
+     * Loads a configuration value, as a number, by its given key. If it doesn't exist, or the
+     * configuration value is not a legal number, an error is thrown.
+     */
+    public double requireDouble(String key) {
+        return getDouble(key).orElseThrow(() -> new ConfigMissingException(fullKey(key)));
+    }
+
+    /**
+     * Loads a configuration value, as a number, by its given key, marking it as a secret.
+     * If it doesn't exist, or the configuration value is not a legal number, an error is thrown.
+     */
+    public Output<Double> requireSecretDouble(String key) {
+        return Output.ofSecret(requireDouble(key));
+    }
+
+    /**
      * Loads a configuration value as a JSON string and deserializes it into an object.
      * If it doesn't exist, or the configuration value cannot be converted
      * using {@link Gson#fromJson(Reader, Class)}, an error is thrown.


### PR DESCRIPTION
## Summary

- Teach the Java program codegen to dispatch to the typed `Config` accessors (`getBoolean`/`requireInteger`/`getDouble`/etc.) based on the PCL config type, so numeric and boolean configs no longer compile-error against `String`.
- Add `requireDouble` and `requireSecretDouble` to `com.pulumi.Config` to mirror the existing typed `require*` family.
- Implement `GenUnaryOpExpression` for `!` and `-`; unknown operators still fall through to `genNYI`.

Fixes #2004.

## Test plan

- [x] `go test -run 'TestLanguage/l1-config-types-primitive$' ./pkg/cmd/pulumi-language-java/`
- [x] `go test -run TestGenerateJavaProgram ./pkg/codegen/...`
- [x] `go test -short ./pkg/...`
- [x] `make lint`
- [x] `cd sdk/java && ./gradlew build`