### PR TITLE
Fix l1-config-types-object language test

### DIFF
--- a/.changes/unreleased/Improvements-l1-config-types-object.yaml
+++ b/.changes/unreleased/Improvements-l1-config-types-object.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Correctly generate object types for program config
+time: 2026-05-18T00:00:00Z
+custom:
+  PR: "2189"
+component: codegen

--- a/.changes/unreleased/Improvements-l1-config-types-object.yaml
+++ b/.changes/unreleased/Improvements-l1-config-types-object.yaml
@@ -2,5 +2,5 @@ kind: Improvements
 body: Correctly generate object types for program config
 time: 2026-05-18T00:00:00Z
 custom:
-  PR: "2189"
+  PR: "2190"
 component: codegen

--- a/pkg/cmd/pulumi-language-java/language_test.go
+++ b/pkg/cmd/pulumi-language-java/language_test.go
@@ -155,7 +155,6 @@ func TestLanguage(t *testing.T) {
 var expectedFailures = map[string]string{
 	"l1-builtin-try":                         "#1683 Fix l1-builtin-try/can",
 	"l1-builtin-can":                         "#1683 Fix l1-builtin-try/can",
-	"l1-config-types-object":                 "https://github.com/pulumi/pulumi-java/issues/2005",
 	"l1-keyword-overlap":                     "#1681 Fix l1-keyword-overlap",
 	"l1-output-string":                       "#1562 Large string literals are not generated correctly",
 	"l1-proxy-index":                         "compilation error",

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/Pulumi.yaml
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-config-types-object
+runtime: java

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/pom.xml
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+		<project xmlns="http://maven.apache.org/POM/4.0.0"
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			<modelVersion>4.0.0</modelVersion>
+
+			<groupId>com.pulumi</groupId>
+			<artifactId>l1-config-types-object</artifactId>
+			<version>1.0-SNAPSHOT</version>
+
+			<properties>
+				<encoding>UTF-8</encoding>
+				<maven.compiler.source>11</maven.compiler.source>
+				<maven.compiler.target>11</maven.compiler.target>
+				<maven.compiler.release>11</maven.compiler.release>
+				<mainClass>generated_program.App</mainClass>
+				<mainArgs/>
+			</properties>
+			
+			<repositories>
+				<repository>
+					<id>repository-0</id>
+					<url>REPOSITORY</url>
+				</repository>
+			</repositories>
+
+			<dependencies>
+				<dependency>
+					<groupId>com.pulumi</groupId>
+					<artifactId>pulumi</artifactId>
+					<version>CORE.VERSION</version>
+				</dependency>
+				
+			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>3.2.2</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<addClasspath>true</addClasspath>
+									<mainClass>${mainClass}</mainClass>
+								</manifest>
+							</archive>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<version>3.4.2</version>
+						<configuration>
+							<archive>
+								<manifest>
+									<addClasspath>true</addClasspath>
+									<mainClass>${mainClass}</mainClass>
+								</manifest>
+							</archive>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>make-my-jar-with-dependencies</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>3.1.0</version>
+						<configuration>
+							<mainClass>${mainClass}</mainClass>
+							<commandlineArgs>${mainArgs}</commandlineArgs>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-wrapper-plugin</artifactId>
+						<version>3.1.1</version>
+						<configuration>
+							<mavenVersion>3.8.5</mavenVersion>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</project>

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
@@ -22,11 +22,16 @@ public class App {
             Map.entry("a", aMap.get("a") + 1),
             Map.entry("b", aMap.get("b") + 1)
         ));
-        final var anObject = config.requireObject("anObject", com.pulumi.core.TypeShape.map(String.class, Object.class));
-        ctx.export("theObject", ((java.util.List) anObject.get("prop")).get(0));
+        final var anObject = config.requireObject("anObject", AnObjectConfig.class);
+        ctx.export("theObject", anObject.prop().get(0));
         final var anyObject = config.requireObject("anyObject", com.pulumi.core.TypeShape.map(String.class, Object.class));
         ctx.export("theThing", ((Number) anyObject.get("a")).doubleValue() + ((Number) anyObject.get("b")).doubleValue());
         final var optionalUntypedObject = config.getObject("optionalUntypedObject", com.pulumi.core.TypeShape.map(String.class, Object.class)).orElse(Map.of("key", "value"));
         ctx.export("defaultUntypedObject", optionalUntypedObject);
+    }
+
+    public static class AnObjectConfig {
+        public java.util.List<Boolean> prop;
+        public java.util.List<Boolean> prop() { return prop; }
     }
 }

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
@@ -31,7 +31,7 @@ public class App {
     }
 
     public static class AnObjectConfig {
-        public java.util.List<Boolean> prop;
+        private java.util.List<Boolean> prop;
         public java.util.List<Boolean> prop() { return prop; }
     }
 }

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
@@ -1,0 +1,32 @@
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        final var config = ctx.config();
+        final var aMap = config.requireObject("aMap", com.pulumi.core.TypeShape.map(String.class, Integer.class));
+        ctx.export("theMap", Map.ofEntries(
+            Map.entry("a", aMap.get("a") + 1),
+            Map.entry("b", aMap.get("b") + 1)
+        ));
+        final var anObject = config.requireObject("anObject", com.pulumi.core.TypeShape.map(String.class, Object.class));
+        ctx.export("theObject", ((java.util.List) anObject.get("prop")).get(0));
+        final var anyObject = config.requireObject("anyObject", com.pulumi.core.TypeShape.map(String.class, Object.class));
+        ctx.export("theThing", ((Number) anyObject.get("a")).doubleValue() + ((Number) anyObject.get("b")).doubleValue());
+        final var optionalUntypedObject = config.getObject("optionalUntypedObject", com.pulumi.core.TypeShape.map(String.class, Object.class)).orElse(Map.of("key", "value"));
+        ctx.export("defaultUntypedObject", optionalUntypedObject);
+    }
+}

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l1-config-types-object/src/main/java/generated_program/App.java
@@ -3,6 +3,7 @@ package generated_program;
 import com.pulumi.Context;
 import com.pulumi.Pulumi;
 import com.pulumi.core.Output;
+import static com.pulumi.codegen.internal.Serialization.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -28,10 +29,26 @@ public class App {
         ctx.export("theThing", ((Number) anyObject.get("a")).doubleValue() + ((Number) anyObject.get("b")).doubleValue());
         final var optionalUntypedObject = config.getObject("optionalUntypedObject", com.pulumi.core.TypeShape.map(String.class, Object.class)).orElse(Map.of("key", "value"));
         ctx.export("defaultUntypedObject", optionalUntypedObject);
+        final var optionalList = config.getObject("optionalList", com.pulumi.core.TypeShape.list(String.class)).orElse(null);
+        final var optionalMap = config.getObject("optionalMap", com.pulumi.core.TypeShape.map(String.class, String.class)).orElse(null);
+        final var optionalObject = config.getObject("optionalObject", OptionalObjectConfig.class).orElse(null);
+        ctx.export("optionalList", optionalList == null ? "null" : serializeJson(
+            optionalList));
+        ctx.export("optionalMap", optionalMap == null ? "null" : serializeJson(
+            optionalMap));
+        ctx.export("optionalObject", optionalObject == null ? "null" : serializeJson(
+            optionalObject));
     }
 
     public static class AnObjectConfig {
         private java.util.List<Boolean> prop;
         public java.util.List<Boolean> prop() { return prop; }
+    }
+
+    public static class OptionalObjectConfig {
+        private Integer other;
+        public Integer other() { return other; }
+        private String prop;
+        public String prop() { return prop; }
     }
 }

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1560,16 +1560,18 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 		secret = "Secret"
 	}
 
-	typeSuffix := ""
+	// `get`/`require` accessor suffix per typed config kind. Object/map/dynamic
+	// kinds use `getObject`/`requireObject` and need a second argument describing
+	// the shape: a `.class` literal for synthesized POJOs, a `TypeShape` builder
+	// expression for collections and dynamic values.
+	typeSuffix := "Object"
 	extraArg := ""
 	switch t := configType.(type) {
 	case *model.ObjectType:
 		className := names.Title(configVariable.Name()) + "Config"
 		g.objectConfigs = append(g.objectConfigs, objectConfigClass{className: className, objType: t})
-		typeSuffix = "Object"
 		extraArg = ", " + className + ".class"
 	case *model.MapType:
-		typeSuffix = "Object"
 		extraArg = ", " + javaTypeShapeExpr(t)
 	default:
 		switch configType {
@@ -1580,8 +1582,9 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 		case model.NumberType:
 			typeSuffix = "Double"
 		case model.DynamicType:
-			typeSuffix = "Object"
 			extraArg = ", " + javaTypeShapeExpr(configType)
+		default:
+			typeSuffix = ""
 		}
 	}
 

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1480,13 +1480,23 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 
 	configType := model.ResolveOutputs(configVariable.Type())
 	typeSuffix := ""
-	switch configType {
-	case model.BoolType:
-		typeSuffix = "Boolean"
-	case model.IntType:
-		typeSuffix = "Integer"
-	case model.NumberType:
-		typeSuffix = "Double"
+	extraArg := ""
+	switch t := configType.(type) {
+	case *model.MapType, *model.ObjectType:
+		typeSuffix = "Object"
+		extraArg = ", " + javaTypeShapeExpr(t)
+	default:
+		switch configType {
+		case model.BoolType:
+			typeSuffix = "Boolean"
+		case model.IntType:
+			typeSuffix = "Integer"
+		case model.NumberType:
+			typeSuffix = "Double"
+		case model.DynamicType:
+			typeSuffix = "Object"
+			extraArg = ", " + javaTypeShapeExpr(configType)
+		}
 	}
 
 	name := names.MakeValidIdentifier(configVariable.Name())
@@ -1497,13 +1507,51 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 	}
 
 	if configVariable.DefaultValue != nil {
-		g.Fgenf(w, "final var %s = config.get%s%s(\"%s\").orElse(%v);",
-			name, secret, typeSuffix, logicalName, configVariable.DefaultValue)
+		g.Fgenf(w, "final var %s = config.get%s%s(\"%s\"%s).orElse(%v);",
+			name, secret, typeSuffix, logicalName, extraArg, configVariable.DefaultValue)
 	} else {
-		g.Fgenf(w, "final var %s = config.require%s%s(\"%s\");",
-			name, secret, typeSuffix, logicalName)
+		g.Fgenf(w, "final var %s = config.require%s%s(\"%s\"%s);",
+			name, secret, typeSuffix, logicalName, extraArg)
 	}
 	g.genNewline(w)
+}
+
+// javaTypeShapeExpr returns a Java expression that constructs a TypeShape describing
+// the given PCL model type. Used when generating typed `requireObject`/`getObject`
+// configuration calls. Object types are flattened to `Map<String, Object>` because
+// the Java codegen does not synthesize classes for inline PCL object shapes.
+func javaTypeShapeExpr(t model.Type) string {
+	switch t := t.(type) {
+	case *model.MapType:
+		return fmt.Sprintf("com.pulumi.core.TypeShape.map(String.class, %s)",
+			javaTypeClassExpr(t.ElementType))
+	case *model.ListType:
+		return fmt.Sprintf("com.pulumi.core.TypeShape.list(%s)",
+			javaTypeClassExpr(t.ElementType))
+	case *model.ObjectType:
+		return "com.pulumi.core.TypeShape.map(String.class, Object.class)"
+	}
+	if t == model.DynamicType {
+		return "com.pulumi.core.TypeShape.map(String.class, Object.class)"
+	}
+	return "com.pulumi.core.TypeShape.of(Object.class)"
+}
+
+// javaTypeClassExpr returns a Java `X.class` expression for a PCL model type,
+// using boxed wrappers for primitives. Complex element types collapse to
+// `Object.class` because Java erases generics in class literals.
+func javaTypeClassExpr(t model.Type) string {
+	switch t {
+	case model.BoolType:
+		return "Boolean.class"
+	case model.IntType:
+		return "Integer.class"
+	case model.NumberType:
+		return "Double.class"
+	case model.StringType:
+		return "String.class"
+	}
+	return "Object.class"
 }
 
 func (g *generator) isFunctionInvoke(localVariable *pcl.LocalVariable) (*schema.Function, bool) {

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -50,6 +50,17 @@ type generator struct {
 	// we should rewrite it as resourceGroup.thenApply(getResourceGroupResult -> getResourceGroupResult.getName())
 	functionInvokes          map[string]*schema.Function
 	emittedTypeImportSymbols codegen.StringSet
+	// Nested static config classes synthesized for `object(...)` config
+	// variables, emitted after the stack method closes. Order is preserved so
+	// generated code is stable.
+	objectConfigs []objectConfigClass
+}
+
+// objectConfigClass captures everything needed to emit a synthesized nested
+// static class for a `config "<name>" "object({...})" {}` declaration.
+type objectConfigClass struct {
+	className string
+	objType   *model.ObjectType
 }
 
 // genComment generates a comment into the output.
@@ -1024,7 +1035,56 @@ func (g *generator) genPostamble(w io.Writer, _ []pcl.Node) {
 		g.genIndent(w)
 		g.Fgen(w, "}\n")
 	})
+	g.genObjectConfigClasses(w)
 	g.Fprint(w, "}\n")
+}
+
+// genObjectConfigClasses emits a nested static class for each `object(...)`
+// config variable encountered, providing a Gson-deserializable POJO with both
+// a public field and a method accessor per property so the generated program
+// can use the existing `.attr()` traversal style.
+func (g *generator) genObjectConfigClasses(w io.Writer) {
+	for _, c := range g.objectConfigs {
+		g.Fprint(w, "\n")
+		g.Fprintf(w, "    public static class %s {\n", c.className)
+		propNames := make([]string, 0, len(c.objType.Properties))
+		for n := range c.objType.Properties {
+			propNames = append(propNames, n)
+		}
+		slices.Sort(propNames)
+		for _, propName := range propNames {
+			propType := c.objType.Properties[propName]
+			javaType := javaPropertyTypeName(model.ResolveOutputs(propType))
+			fieldName := names.MakeValidIdentifier(propName)
+			g.Fprintf(w, "        public %s %s;\n", javaType, fieldName)
+			g.Fprintf(w, "        public %s %s() { return %s; }\n", javaType, fieldName, fieldName)
+		}
+		g.Fprint(w, "    }\n")
+	}
+}
+
+// javaPropertyTypeName renders a PCL property type as a Java type expression
+// suitable for a config POJO field. Unsupported / dynamic shapes fall back to
+// `Object`, which Gson still deserializes losslessly via its generic handling.
+func javaPropertyTypeName(t model.Type) string {
+	t = unwrapOptional(t)
+	switch t {
+	case model.BoolType:
+		return "Boolean"
+	case model.IntType:
+		return "Integer"
+	case model.NumberType:
+		return "Double"
+	case model.StringType:
+		return "String"
+	}
+	switch t := t.(type) {
+	case *model.ListType:
+		return "java.util.List<" + javaPropertyTypeName(t.ElementType) + ">"
+	case *model.MapType:
+		return "java.util.Map<String, " + javaPropertyTypeName(t.ElementType) + ">"
+	}
+	return "Object"
 }
 
 // resourceTypeName computes the Java resource class name for the given resource.
@@ -1479,10 +1539,22 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 	g.genIndent(w)
 
 	configType := model.ResolveOutputs(configVariable.Type())
+	name := names.MakeValidIdentifier(configVariable.Name())
+	logicalName := configVariable.LogicalName()
+	secret := ""
+	if configVariable.Secret {
+		secret = "Secret"
+	}
+
 	typeSuffix := ""
 	extraArg := ""
 	switch t := configType.(type) {
-	case *model.MapType, *model.ObjectType:
+	case *model.ObjectType:
+		className := names.Title(configVariable.Name()) + "Config"
+		g.objectConfigs = append(g.objectConfigs, objectConfigClass{className: className, objType: t})
+		typeSuffix = "Object"
+		extraArg = ", " + className + ".class"
+	case *model.MapType:
 		typeSuffix = "Object"
 		extraArg = ", " + javaTypeShapeExpr(t)
 	default:
@@ -1499,13 +1571,6 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 		}
 	}
 
-	name := names.MakeValidIdentifier(configVariable.Name())
-	logicalName := configVariable.LogicalName()
-	secret := ""
-	if configVariable.Secret {
-		secret = "Secret"
-	}
-
 	if configVariable.DefaultValue != nil {
 		g.Fgenf(w, "final var %s = config.get%s%s(\"%s\"%s).orElse(%v);",
 			name, secret, typeSuffix, logicalName, extraArg, configVariable.DefaultValue)
@@ -1517,8 +1582,8 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 }
 
 // javaTypeShapeExpr returns a Java expression that constructs a TypeShape for
-// the given PCL model type. Inline object shapes flatten to `Map<String, Object>`
-// because the Java codegen does not synthesize classes for them.
+// the given PCL model type. Used for `map(...)` and dynamic configs; inline
+// `object(...)` configs use synthesized classes instead.
 func javaTypeShapeExpr(t model.Type) string {
 	switch t := t.(type) {
 	case *model.MapType:
@@ -1527,8 +1592,6 @@ func javaTypeShapeExpr(t model.Type) string {
 	case *model.ListType:
 		return fmt.Sprintf("com.pulumi.core.TypeShape.list(%s)",
 			javaTypeClassExpr(t.ElementType))
-	case *model.ObjectType:
-		return "com.pulumi.core.TypeShape.map(String.class, Object.class)"
 	}
 	if t == model.DynamicType {
 		return "com.pulumi.core.TypeShape.map(String.class, Object.class)"

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1068,6 +1068,20 @@ func (g *generator) genObjectConfigClasses(w io.Writer) {
 // `Object`, which Gson still deserializes losslessly via its generic handling.
 func javaPropertyTypeName(t model.Type) string {
 	t = unwrapOptional(t)
+	switch t := t.(type) {
+	case *model.ListType:
+		return "java.util.List<" + javaPropertyTypeName(t.ElementType) + ">"
+	case *model.MapType:
+		return "java.util.Map<String, " + javaPropertyTypeName(t.ElementType) + ">"
+	}
+	return javaErasedTypeName(t)
+}
+
+// javaErasedTypeName returns the raw Java class name for a PCL type, dropping
+// any generic parameterization. Suitable for `.class` literals and any other
+// context where Java erasure forbids generics.
+func javaErasedTypeName(t model.Type) string {
+	t = unwrapOptional(t)
 	switch t {
 	case model.BoolType:
 		return "Boolean"
@@ -1078,11 +1092,11 @@ func javaPropertyTypeName(t model.Type) string {
 	case model.StringType:
 		return "String"
 	}
-	switch t := t.(type) {
+	switch t.(type) {
 	case *model.ListType:
-		return "java.util.List<" + javaPropertyTypeName(t.ElementType) + ">"
+		return "java.util.List"
 	case *model.MapType:
-		return "java.util.Map<String, " + javaPropertyTypeName(t.ElementType) + ">"
+		return "java.util.Map"
 	}
 	return "Object"
 }
@@ -1600,20 +1614,8 @@ func javaTypeShapeExpr(t model.Type) string {
 }
 
 // javaTypeClassExpr returns a `X.class` expression for a PCL model type.
-// Complex element types collapse to `Object.class` because Java erases generics
-// in class literals.
 func javaTypeClassExpr(t model.Type) string {
-	switch t {
-	case model.BoolType:
-		return "Boolean.class"
-	case model.IntType:
-		return "Integer.class"
-	case model.NumberType:
-		return "Double.class"
-	case model.StringType:
-		return "String.class"
-	}
-	return "Object.class"
+	return javaErasedTypeName(t) + ".class"
 }
 
 func (g *generator) isFunctionInvoke(localVariable *pcl.LocalVariable) (*schema.Function, bool) {

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1516,10 +1516,9 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 	g.genNewline(w)
 }
 
-// javaTypeShapeExpr returns a Java expression that constructs a TypeShape describing
-// the given PCL model type. Used when generating typed `requireObject`/`getObject`
-// configuration calls. Object types are flattened to `Map<String, Object>` because
-// the Java codegen does not synthesize classes for inline PCL object shapes.
+// javaTypeShapeExpr returns a Java expression that constructs a TypeShape for
+// the given PCL model type. Inline object shapes flatten to `Map<String, Object>`
+// because the Java codegen does not synthesize classes for them.
 func javaTypeShapeExpr(t model.Type) string {
 	switch t := t.(type) {
 	case *model.MapType:
@@ -1537,9 +1536,9 @@ func javaTypeShapeExpr(t model.Type) string {
 	return "com.pulumi.core.TypeShape.of(Object.class)"
 }
 
-// javaTypeClassExpr returns a Java `X.class` expression for a PCL model type,
-// using boxed wrappers for primitives. Complex element types collapse to
-// `Object.class` because Java erases generics in class literals.
+// javaTypeClassExpr returns a `X.class` expression for a PCL model type.
+// Complex element types collapse to `Object.class` because Java erases generics
+// in class literals.
 func javaTypeClassExpr(t model.Type) string {
 	switch t {
 	case model.BoolType:

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1040,9 +1040,9 @@ func (g *generator) genPostamble(w io.Writer, _ []pcl.Node) {
 }
 
 // genObjectConfigClasses emits a nested static class for each `object(...)`
-// config variable encountered, providing a Gson-deserializable POJO with both
-// a public field and a method accessor per property so the generated program
-// can use the existing `.attr()` traversal style.
+// config variable encountered. Each property becomes a private field (Gson
+// writes it reflectively during deserialization) exposed through a method
+// accessor that matches the `.attr()` style the traversal codegen emits.
 func (g *generator) genObjectConfigClasses(w io.Writer) {
 	for _, c := range g.objectConfigs {
 		g.Fprint(w, "\n")
@@ -1056,7 +1056,7 @@ func (g *generator) genObjectConfigClasses(w io.Writer) {
 			propType := c.objType.Properties[propName]
 			javaType := javaPropertyTypeName(model.ResolveOutputs(propType))
 			fieldName := names.MakeValidIdentifier(propName)
-			g.Fprintf(w, "        public %s %s;\n", javaType, fieldName)
+			g.Fprintf(w, "        private %s %s;\n", javaType, fieldName)
 			g.Fprintf(w, "        public %s %s() { return %s; }\n", javaType, fieldName, fieldName)
 		}
 		g.Fprint(w, "    }\n")

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1552,7 +1552,7 @@ func (g *generator) genResource(w io.Writer, resource *pcl.Resource) {
 func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVariable) {
 	g.genIndent(w)
 
-	configType := model.ResolveOutputs(configVariable.Type())
+	configType := unwrapOptional(model.ResolveOutputs(configVariable.Type()))
 	name := names.MakeValidIdentifier(configVariable.Name())
 	logicalName := configVariable.LogicalName()
 	secret := ""
@@ -1571,7 +1571,7 @@ func (g *generator) genConfigVariable(w io.Writer, configVariable *pcl.ConfigVar
 		className := names.Title(configVariable.Name()) + "Config"
 		g.objectConfigs = append(g.objectConfigs, objectConfigClass{className: className, objType: t})
 		extraArg = ", " + className + ".class"
-	case *model.MapType:
+	case *model.MapType, *model.ListType:
 		extraArg = ", " + javaTypeShapeExpr(t)
 	default:
 		switch configType {

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -586,7 +586,7 @@ func (g *generator) genJSON(w io.Writer, expr model.Expression) {
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {
 	collType := model.ResolveOutputs(expr.Collection.Type())
-	if isMapLikeType(collType, false) {
+	if isMapLikeType(collType) {
 		g.Fgenf(w, "%v.get(%v)", expr.Collection, expr.Key)
 		return
 	}
@@ -846,15 +846,10 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 ) {
 	hasParts := len(parts) >= len(traversal)+1
 
-	// `*model.ObjectType` is shared between user `object({...})` configs (which
-	// we lower to `Map<String, Object>`) and synthetic objects like the `range`
-	// iteration variable (which keep generated `.attr()` getters). Only the
-	// config-rooted case wants map-style access.
-	objectAsMap := hasParts && isConfigVariableRoot(parts[0])
-
 	chain := root
-	// Set once the chain has crossed a `Map<String, Object>` boundary; further
-	// typed access (`.get(int)` on a list) then needs an explicit cast.
+	// Set once the chain has crossed a `Map<String, Object>` boundary (i.e. an
+	// access on a dynamic-rooted value); further typed access (`.get(int)` on
+	// a list) then needs an explicit cast.
 	staticTypeErased := false
 
 	for i, part := range traversal {
@@ -862,7 +857,7 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 		if hasParts {
 			sourceType = unwrapOptional(model.GetTraversableType(parts[i]))
 		}
-		mapLike := isMapLikeType(sourceType, objectAsMap)
+		mapLike := isMapLikeType(sourceType)
 		listLike := isListLikeType(sourceType)
 
 		var key cty.Value
@@ -902,20 +897,10 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 	fmt.Fprint(w, chain)
 }
 
-// isConfigVariableRoot reports whether the traversal root is a `*pcl.ConfigVariable`,
-// the only inline-object value the Java codegen emits as `Map<String, Object>`.
-func isConfigVariableRoot(t model.Traversable) bool {
-	_, ok := t.(*pcl.ConfigVariable)
-	return ok
-}
-
 // mapValueErasesToObject reports whether `.get(key)` on this PCL type returns
 // Java `Object` at compile time. `map(int)` and similar narrow generics expose
-// their element type; inline objects and `map(object/dynamic)` collapse to `Object`.
+// their element type; `map(object/dynamic)` collapses to `Object`.
 func mapValueErasesToObject(t model.Type) bool {
-	if _, ok := t.(*model.ObjectType); ok {
-		return true
-	}
 	if mt, ok := t.(*model.MapType); ok {
 		if _, objectElement := mt.ElementType.(*model.ObjectType); objectElement {
 			return true
@@ -926,15 +911,13 @@ func mapValueErasesToObject(t model.Type) bool {
 }
 
 // isMapLikeType reports whether attribute access on this PCL type should lower
-// to `.get("key")` instead of a generated getter. `objectAsMap` opts
-// `*model.ObjectType` in — see `genRelativeTraversal` for when this is set.
-func isMapLikeType(t model.Type, objectAsMap bool) bool {
+// to `.get("key")`. `*model.ObjectType` keeps generated `.attr()` getters —
+// `object(...)` configs now have synthesized POJOs and `range`-style synthetic
+// objects already use method accessors.
+func isMapLikeType(t model.Type) bool {
 	t = unwrapOptional(t)
 	if _, ok := t.(*model.MapType); ok {
 		return true
-	}
-	if _, ok := t.(*model.ObjectType); ok {
-		return objectAsMap
 	}
 	return t == model.DynamicType
 }

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -3,6 +3,7 @@
 package java
 
 import (
+	"fmt"
 	"io"
 	"math/big"
 	"strings"
@@ -217,6 +218,27 @@ func (g *generator) genIntrinsic(w io.Writer, from model.Expression, to model.Ty
 	output, isOutput := targetType.(*model.OutputType)
 	if isOutput {
 		targetType = output.ElementType
+	}
+
+	// Conversion from a dynamically-typed value (Java `Object` at the call site,
+	// e.g. the result of `Map<String, Object>.get(...)`) to a concrete numeric
+	// type requires an explicit `Number` cast so Java arithmetic compiles.
+	fromType := unwrapOptional(model.ResolveOutputs(from.Type()))
+	if fromType == model.DynamicType {
+		switch {
+		case targetType.Equals(model.NumberType):
+			g.Fgenf(w, "((Number) %.v).doubleValue()", from)
+			return
+		case targetType.Equals(model.IntType):
+			g.Fgenf(w, "((Number) %.v).intValue()", from)
+			return
+		case targetType.Equals(model.BoolType):
+			g.Fgenf(w, "((Boolean) %.v)", from)
+			return
+		case targetType.Equals(model.StringType):
+			g.Fgenf(w, "((String) %.v)", from)
+			return
+		}
 	}
 
 	if targetType.Equals(model.NumberType) || targetType.Equals(model.IntType) {
@@ -564,6 +586,11 @@ func (g *generator) genJSON(w io.Writer, expr model.Expression) {
 }
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {
+	collType := model.ResolveOutputs(expr.Collection.Type())
+	if isMapLikeType(collType, false) {
+		g.Fgenf(w, "%v.get(%v)", expr.Collection, expr.Key)
+		return
+	}
 	g.Fgenf(w, "%v[%v]", expr.Collection, expr.Key)
 }
 
@@ -815,10 +842,32 @@ func (g *generator) genObjectConsExpressionWithTypeName(
 	}
 }
 
-func (g *generator) genRelativeTraversal(w io.Writer,
-	traversal hcl.Traversal, _ []model.Traversable, _ *schema.ObjectType,
+func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
+	parts []model.Traversable, root string,
 ) {
-	for _, part := range traversal {
+	hasParts := len(parts) >= len(traversal)+1
+
+	// Inline PCL `object({...})` types share `*model.ObjectType` with synthetic
+	// objects like the `range` iteration variable, but only the former are
+	// lowered to `Map<String, Object>` in Java (via `requireObject`/`getObject`).
+	// Treat object traversals as map-like only when the chain is rooted at a
+	// config variable, where this lowering applies.
+	objectAsMap := hasParts && isConfigVariableRoot(parts[0])
+
+	chain := root
+	// staticTypeErased becomes true once the chain has crossed a
+	// `Map<String, Object>` / `Object` boundary, so subsequent typed accesses
+	// (`.get(int)` on a list) need an explicit cast to compile.
+	staticTypeErased := false
+
+	for i, part := range traversal {
+		var sourceType model.Type
+		if hasParts {
+			sourceType = unwrapOptional(model.GetTraversableType(parts[i]))
+		}
+		mapLike := isMapLikeType(sourceType, objectAsMap)
+		listLike := isListLikeType(sourceType)
+
 		var key cty.Value
 		switch part := part.(type) {
 		case hcl.TraverseAttr:
@@ -829,38 +878,119 @@ func (g *generator) genRelativeTraversal(w io.Writer,
 			contract.Failf("unexpected traversal part of type %T (%v)", part, part.SourceRange())
 		}
 
-		// TODO: what do we do with optionals in Java
-		// if model.IsOptionalType(model.GetTraversableType(parts[i])) {
-		// 	g.Fgen(w, "?")
-		// }
-
 		switch key.Type() {
 		case cty.String:
-			g.Fgenf(w, ".%s()", key.AsString())
+			if mapLike {
+				chain = fmt.Sprintf("%s.get(\"%s\")", chain, key.AsString())
+				staticTypeErased = sourceType == model.DynamicType ||
+					mapValueErasesToObject(sourceType)
+			} else {
+				chain = fmt.Sprintf("%s.%s()", chain, key.AsString())
+			}
 		case cty.Number:
 			idx, _ := key.AsBigFloat().Int64()
-			g.Fgenf(w, "[%d]", idx)
+			if listLike {
+				if staticTypeErased {
+					chain = fmt.Sprintf("((java.util.List) %s)", chain)
+					staticTypeErased = false
+				}
+				chain = fmt.Sprintf("%s.get(%d)", chain, idx)
+			} else {
+				chain = fmt.Sprintf("%s[%d]", chain, idx)
+			}
 		default:
 			contract.Failf("unexpected traversal key of type %T (%v)", key, key.AsString())
 		}
 	}
+	fmt.Fprint(w, chain)
+}
+
+// isConfigVariableRoot reports whether the traversal root is a PCL
+// `*pcl.ConfigVariable`, which is the only inline-object value the Java codegen
+// emits as `Map<String, Object>` rather than a typed Java class.
+func isConfigVariableRoot(t model.Traversable) bool {
+	_, ok := t.(*pcl.ConfigVariable)
+	return ok
+}
+
+// mapValueErasesToObject reports whether `.get(key)` on a value of this PCL
+// type returns Java `Object` at compile time. Object types and map-of-Object
+// (the runtime shape of any inline PCL object) erase to `Object`, while
+// `map(int)` and similar narrow generics expose their element type.
+func mapValueErasesToObject(t model.Type) bool {
+	if _, ok := t.(*model.ObjectType); ok {
+		return true
+	}
+	if mt, ok := t.(*model.MapType); ok {
+		if _, objectElement := mt.ElementType.(*model.ObjectType); objectElement {
+			return true
+		}
+		return mt.ElementType == model.DynamicType
+	}
+	return false
+}
+
+// isMapLikeType reports whether attribute access on a value of this PCL type
+// should be lowered to `.get("key")` rather than to a generated getter.
+// `objectAsMap` controls whether `*model.ObjectType` participates — see the
+// note in `genRelativeTraversal`.
+func isMapLikeType(t model.Type, objectAsMap bool) bool {
+	t = unwrapOptional(t)
+	if _, ok := t.(*model.MapType); ok {
+		return true
+	}
+	if _, ok := t.(*model.ObjectType); ok {
+		return objectAsMap
+	}
+	return t == model.DynamicType
+}
+
+// isListLikeType reports whether numeric indexing on a value of this PCL type
+// should be lowered to `.get(idx)` (Java `List`) rather than `[idx]` (array).
+func isListLikeType(t model.Type) bool {
+	t = unwrapOptional(t)
+	if _, ok := t.(*model.ListType); ok {
+		return true
+	}
+	if _, ok := t.(*model.TupleType); ok {
+		return true
+	}
+	return false
+}
+
+// unwrapOptional strips a `union(T, none)` wrapper applied by the PCL binder
+// for nullable property types, returning the underlying non-null type. If `t`
+// is not a 2-arm optional union, it is returned unchanged.
+func unwrapOptional(t model.Type) model.Type {
+	u, ok := t.(*model.UnionType)
+	if !ok {
+		return t
+	}
+	var inner model.Type
+	for _, arm := range u.ElementTypes {
+		if arm == model.NoneType {
+			continue
+		}
+		if inner != nil {
+			return t
+		}
+		inner = arm
+	}
+	if inner == nil {
+		return t
+	}
+	return inner
 }
 
 func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.RelativeTraversalExpression) {
-	g.Fgenf(w, "%.20v", expr.Source)
-	g.genRelativeTraversal(w, expr.Traversal, expr.Parts, nil)
+	var buf strings.Builder
+	g.Fgenf(&buf, "%.20v", expr.Source)
+	g.genRelativeTraversal(w, expr.Traversal, expr.Parts, buf.String())
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
 	rootName := names.MakeValidIdentifier(expr.RootName)
-	g.Fgen(w, rootName)
-	var objType *schema.ObjectType
-	if resource, ok := expr.Parts[0].(*pcl.Resource); ok {
-		if schemaType, ok := pcl.GetSchemaForType(resource.InputType); ok {
-			objType, _ = schemaType.(*schema.ObjectType)
-		}
-	}
-	g.genRelativeTraversal(w, expr.Traversal.SimpleSplit().Rel, expr.Parts, objType)
+	g.genRelativeTraversal(w, expr.Traversal.SimpleSplit().Rel, expr.Parts, rootName)
 }
 
 func (g *generator) GenSplatExpression(w io.Writer, expr *model.SplatExpression) {

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -220,9 +220,8 @@ func (g *generator) genIntrinsic(w io.Writer, from model.Expression, to model.Ty
 		targetType = output.ElementType
 	}
 
-	// Conversion from a dynamically-typed value (Java `Object` at the call site,
-	// e.g. the result of `Map<String, Object>.get(...)`) to a concrete numeric
-	// type requires an explicit `Number` cast so Java arithmetic compiles.
+	// Dynamic values land in Java as `Object` (e.g. from `Map<String, Object>.get`),
+	// so converting to a concrete type needs an explicit cast for arithmetic to compile.
 	fromType := unwrapOptional(model.ResolveOutputs(from.Type()))
 	if fromType == model.DynamicType {
 		switch {
@@ -847,17 +846,15 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 ) {
 	hasParts := len(parts) >= len(traversal)+1
 
-	// Inline PCL `object({...})` types share `*model.ObjectType` with synthetic
-	// objects like the `range` iteration variable, but only the former are
-	// lowered to `Map<String, Object>` in Java (via `requireObject`/`getObject`).
-	// Treat object traversals as map-like only when the chain is rooted at a
-	// config variable, where this lowering applies.
+	// `*model.ObjectType` is shared between user `object({...})` configs (which
+	// we lower to `Map<String, Object>`) and synthetic objects like the `range`
+	// iteration variable (which keep generated `.attr()` getters). Only the
+	// config-rooted case wants map-style access.
 	objectAsMap := hasParts && isConfigVariableRoot(parts[0])
 
 	chain := root
-	// staticTypeErased becomes true once the chain has crossed a
-	// `Map<String, Object>` / `Object` boundary, so subsequent typed accesses
-	// (`.get(int)` on a list) need an explicit cast to compile.
+	// Set once the chain has crossed a `Map<String, Object>` boundary; further
+	// typed access (`.get(int)` on a list) then needs an explicit cast.
 	staticTypeErased := false
 
 	for i, part := range traversal {
@@ -905,18 +902,16 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 	fmt.Fprint(w, chain)
 }
 
-// isConfigVariableRoot reports whether the traversal root is a PCL
-// `*pcl.ConfigVariable`, which is the only inline-object value the Java codegen
-// emits as `Map<String, Object>` rather than a typed Java class.
+// isConfigVariableRoot reports whether the traversal root is a `*pcl.ConfigVariable`,
+// the only inline-object value the Java codegen emits as `Map<String, Object>`.
 func isConfigVariableRoot(t model.Traversable) bool {
 	_, ok := t.(*pcl.ConfigVariable)
 	return ok
 }
 
-// mapValueErasesToObject reports whether `.get(key)` on a value of this PCL
-// type returns Java `Object` at compile time. Object types and map-of-Object
-// (the runtime shape of any inline PCL object) erase to `Object`, while
-// `map(int)` and similar narrow generics expose their element type.
+// mapValueErasesToObject reports whether `.get(key)` on this PCL type returns
+// Java `Object` at compile time. `map(int)` and similar narrow generics expose
+// their element type; inline objects and `map(object/dynamic)` collapse to `Object`.
 func mapValueErasesToObject(t model.Type) bool {
 	if _, ok := t.(*model.ObjectType); ok {
 		return true
@@ -930,10 +925,9 @@ func mapValueErasesToObject(t model.Type) bool {
 	return false
 }
 
-// isMapLikeType reports whether attribute access on a value of this PCL type
-// should be lowered to `.get("key")` rather than to a generated getter.
-// `objectAsMap` controls whether `*model.ObjectType` participates — see the
-// note in `genRelativeTraversal`.
+// isMapLikeType reports whether attribute access on this PCL type should lower
+// to `.get("key")` instead of a generated getter. `objectAsMap` opts
+// `*model.ObjectType` in — see `genRelativeTraversal` for when this is set.
 func isMapLikeType(t model.Type, objectAsMap bool) bool {
 	t = unwrapOptional(t)
 	if _, ok := t.(*model.MapType); ok {
@@ -958,9 +952,9 @@ func isListLikeType(t model.Type) bool {
 	return false
 }
 
-// unwrapOptional strips a `union(T, none)` wrapper applied by the PCL binder
-// for nullable property types, returning the underlying non-null type. If `t`
-// is not a 2-arm optional union, it is returned unchanged.
+// unwrapOptional strips a `union(T, none)` wrapper the PCL binder applies to
+// nullable property types, returning T. Non-optional unions and non-unions pass
+// through unchanged.
 func unwrapOptional(t model.Type) model.Type {
 	u, ok := t.(*model.UnionType)
 	if !ok {

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -925,11 +925,8 @@ func isMapLikeType(t model.Type) bool {
 // isListLikeType reports whether numeric indexing on a value of this PCL type
 // should be lowered to `.get(idx)` (Java `List`) rather than `[idx]` (array).
 func isListLikeType(t model.Type) bool {
-	t = unwrapOptional(t)
-	if _, ok := t.(*model.ListType); ok {
-		return true
-	}
-	if _, ok := t.(*model.TupleType); ok {
+	switch unwrapOptional(t).(type) {
+	case *model.ListType, *model.TupleType:
 		return true
 	}
 	return false

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -585,8 +585,7 @@ func (g *generator) genJSON(w io.Writer, expr model.Expression) {
 }
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {
-	collType := model.ResolveOutputs(expr.Collection.Type())
-	if isMapLikeType(collType) {
+	if isMapLikeType(unwrapOptional(model.ResolveOutputs(expr.Collection.Type()))) {
 		g.Fgenf(w, "%v.get(%v)", expr.Collection, expr.Key)
 		return
 	}
@@ -845,20 +844,12 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 	parts []model.Traversable, root string,
 ) {
 	hasParts := len(parts) >= len(traversal)+1
-
-	chain := root
-	// Set once the chain has crossed a `Map<String, Object>` boundary (i.e. an
-	// access on a dynamic-rooted value); further typed access (`.get(int)` on
-	// a list) then needs an explicit cast.
-	staticTypeErased := false
-
+	fmt.Fprint(w, root)
 	for i, part := range traversal {
 		var sourceType model.Type
 		if hasParts {
 			sourceType = unwrapOptional(model.GetTraversableType(parts[i]))
 		}
-		mapLike := isMapLikeType(sourceType)
-		listLike := isListLikeType(sourceType)
 
 		var key cty.Value
 		switch part := part.(type) {
@@ -872,50 +863,29 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal,
 
 		switch key.Type() {
 		case cty.String:
-			if mapLike {
-				chain = fmt.Sprintf("%s.get(\"%s\")", chain, key.AsString())
-				staticTypeErased = sourceType == model.DynamicType ||
-					mapValueErasesToObject(sourceType)
+			if isMapLikeType(sourceType) {
+				g.Fgenf(w, ".get(\"%s\")", key.AsString())
 			} else {
-				chain = fmt.Sprintf("%s.%s()", chain, key.AsString())
+				g.Fgenf(w, ".%s()", key.AsString())
 			}
 		case cty.Number:
 			idx, _ := key.AsBigFloat().Int64()
-			if listLike {
-				if staticTypeErased {
-					chain = fmt.Sprintf("((java.util.List) %s)", chain)
-					staticTypeErased = false
-				}
-				chain = fmt.Sprintf("%s.get(%d)", chain, idx)
+			if isListLikeType(sourceType) {
+				g.Fgenf(w, ".get(%d)", idx)
 			} else {
-				chain = fmt.Sprintf("%s[%d]", chain, idx)
+				g.Fgenf(w, "[%d]", idx)
 			}
 		default:
 			contract.Failf("unexpected traversal key of type %T (%v)", key, key.AsString())
 		}
 	}
-	fmt.Fprint(w, chain)
-}
-
-// mapValueErasesToObject reports whether `.get(key)` on this PCL type returns
-// Java `Object` at compile time. `map(int)` and similar narrow generics expose
-// their element type; `map(object/dynamic)` collapses to `Object`.
-func mapValueErasesToObject(t model.Type) bool {
-	if mt, ok := t.(*model.MapType); ok {
-		if _, objectElement := mt.ElementType.(*model.ObjectType); objectElement {
-			return true
-		}
-		return mt.ElementType == model.DynamicType
-	}
-	return false
 }
 
 // isMapLikeType reports whether attribute access on this PCL type should lower
 // to `.get("key")`. `*model.ObjectType` keeps generated `.attr()` getters —
-// `object(...)` configs now have synthesized POJOs and `range`-style synthetic
-// objects already use method accessors.
+// `object(...)` configs are synthesized as POJOs and `range`-style synthetic
+// objects already use method accessors. Callers must unwrap optionals first.
 func isMapLikeType(t model.Type) bool {
-	t = unwrapOptional(t)
 	if _, ok := t.(*model.MapType); ok {
 		return true
 	}
@@ -924,8 +894,9 @@ func isMapLikeType(t model.Type) bool {
 
 // isListLikeType reports whether numeric indexing on a value of this PCL type
 // should be lowered to `.get(idx)` (Java `List`) rather than `[idx]` (array).
+// Callers must unwrap optionals first.
 func isListLikeType(t model.Type) bool {
-	switch unwrapOptional(t).(type) {
+	switch t.(type) {
 	case *model.ListType, *model.TupleType:
 		return true
 	}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/Config.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/Config.java
@@ -277,6 +277,22 @@ public class Config {
     }
 
     /**
+     * Loads a configuration value as a JSON string and deserializes it into an object using the
+     * given {@link TypeShape}. If it doesn't exist, an error is thrown.
+     */
+    public <T> T requireObject(String key, TypeShape<T> shapeOfT) {
+        return getObject(key, shapeOfT).orElseThrow(() -> new ConfigMissingException(fullKey(key)));
+    }
+
+    /**
+     * Loads a configuration value as a JSON string and deserializes it into an object using the
+     * given {@link TypeShape}, marking it as a secret. If it doesn't exist, an error is thrown.
+     */
+    public <T> Output<T> requireSecretObject(String key, TypeShape<T> shapeOfT) {
+        return Output.ofSecret(requireObject(key, shapeOfT));
+    }
+
+    /**
      * Turns a simple configuration key into a fully resolved one, by prepending the bag's name.
      */
     private String fullKey(String key) {

--- a/sdk/java/pulumi/src/main/java/com/pulumi/codegen/internal/Serialization.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/codegen/internal/Serialization.java
@@ -18,6 +18,15 @@ public class Serialization {
     }
 
     /**
+     * Converts any value (list, string, POJO, ...) into a JSON string.
+     * This function maps to the toJSON(...) function from PCL for non-map arguments.
+     */
+    public static String serializeJson(Object object) {
+        var gson = new Gson();
+        return gson.toJson(object);
+    }
+
+    /**
      * Accepts an array of Entry(String, Object) values to build up a Map(String, Object).
      * The entries are usually created using the jsonProperty(String key, Object value) function.
      */


### PR DESCRIPTION
## Summary

Implements `l1-config-types-object` by teaching the Java program codegen to handle map, object, and dynamic configuration types.

- **`object(...)` configs**: synthesize a nested static class `<Name>Config` inside `App` with a private field and method accessor per property. The retrieval call becomes `config.requireObject(\"<key>\", <Name>Config.class)`, which Gson deserializes via reflection.
- **`map(...)` configs**: lower to `config.requireObject(key, TypeShape.map(String.class, <Element>.class))`, with attribute and index access generating `.get(key)` for the resulting `java.util.Map`.
- **Dynamic / untyped configs** (`config \"x\" {}`): retrieved as `Map<String, Object>` via the dynamic `TypeShape`. The intrinsic-convert lowering emits a `((Number) ...).doubleValue()` / `((Boolean) ...)` / `((String) ...)` cast so arithmetic and equality on dynamic values compiles. The traversal tracks when it has crossed a dynamic boundary and inserts a `(java.util.List)` cast before any subsequent list indexing.
- **SDK**: adds `Config.requireObject(key, TypeShape)` and `Config.requireSecretObject(key, TypeShape)`, mirroring the existing `Class<T>` overloads.

Fixes #2005