### PR TITLE
Cache schema loader during Java package generation

### DIFF
--- a/.changes/unreleased/bug-fixes-2212.yaml
+++ b/.changes/unreleased/bug-fixes-2212.yaml
@@ -1,0 +1,6 @@
+component: language
+kind: bug-fixes
+body: Cache schema loading during Java package generation
+time: 2026-06-02T08:57:52.36423-04:00
+custom:
+    PR: "2212"

--- a/pkg/cmd/pulumi-language-java/main.go
+++ b/pkg/cmd/pulumi-language-java/main.go
@@ -990,6 +990,7 @@ func (host *javaLanguageHost) GeneratePackage(
 	if err != nil {
 		return nil, err
 	}
+	cachedLoader := schema.NewCachedLoader(loader)
 
 	var spec schema.PackageSpec
 	err = json.Unmarshal([]byte(req.Schema), &spec)
@@ -1013,7 +1014,7 @@ func (host *javaLanguageHost) GeneratePackage(
 		}, nil
 	}
 
-	pkg, bindDiags, err := schema.BindSpec(*dedupedSpec, loader, schema.ValidationOptions{
+	pkg, bindDiags, err := schema.BindSpec(*dedupedSpec, cachedLoader, schema.ValidationOptions{
 		AllowDanglingReferences: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

While troubleshooting an AWSX dependency-update build, `make generate_java` was causing `pulumi-language-java` memory usage to grow rapidly until the local machine became unstable. The AWSX schema itself was small, but it referenced the much larger AWS provider schema many times.

The package generation path was passing the raw `schema.LoaderClient` into `schema.BindSpec`, which meant repeated external references could repeatedly resolve through the loader. NodeJS and Python already wrap this loader with `schema.NewCachedLoader` in their package generation paths.

This change applies the same caching pattern to Java package generation.

## Details

- Wrap the `GeneratePackage` loader with `schema.NewCachedLoader`.
- Pass the cached loader into `schema.BindSpec`.
- This avoids repeatedly loading/binding the same external package schema during package generation.

## Validation

- `mise exec -- go test ./pkg/cmd/pulumi-language-java -run '^$'`
- Built the patched `pulumi-language-java`.
- Re-ran the AWSX `make generate_java` path with the patched binary:
  - completed successfully
  - peak RSS stayed under 500 MB
  - previously the same path exceeded 5 GB within ~30 seconds and continued climbing