### PR TITLE
gen-sdk: fix Java SDK build.gradle description escaping

### DIFF
--- a/.changes/unreleased/bug-fixes-2211.yaml
+++ b/.changes/unreleased/bug-fixes-2211.yaml
@@ -1,0 +1,6 @@
+component: language
+kind: bug-fixes
+body: Emit package descriptions in generated Java build.gradle files as Groovy dollar-slashy string literals so multi-line and quoted schema descriptions produce valid Gradle builds without post-processing
+time: 2026-06-05T12:00:00.00000-04:00
+custom:
+    PR: "2211"

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/alpha-3.0.0-alpha.1.internal/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/alpha-3.0.0-alpha.1.internal/build.gradle
@@ -97,7 +97,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/any-type-function-15.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/any-type-function-15.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/asset-archive-5.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/asset-archive-5.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/byepackage-2.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/byepackage-2.0.0/build.gradle
@@ -103,7 +103,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/camelNames-19.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/camelNames-19.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/component-13.3.7/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/component-13.3.7/build.gradle
@@ -97,7 +97,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/component-property-deps-1.33.7/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/component-property-deps-1.33.7/build.gradle
@@ -97,7 +97,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/config-9.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/config-9.0.0/build.gradle
@@ -99,7 +99,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/fail_on_create-4.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/fail_on_create-4.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/goodbye-2.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/goodbye-2.0.0/build.gradle
@@ -103,7 +103,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/hipackage-2.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/hipackage-2.0.0/build.gradle
@@ -103,7 +103,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/keywords-20.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/keywords-20.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/large-4.3.2/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/large-4.3.2/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/names-6.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/names-6.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/namespaced-16.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/namespaced-16.0.0/build.gradle
@@ -97,7 +97,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/nestedobject-1.42.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/nestedobject-1.42.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/output-23.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/output-23.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/plain-13.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/plain-13.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/plaincomponent-36.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/plaincomponent-36.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/primitive-7.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/primitive-7.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/primitive-ref-11.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/primitive-ref-11.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/ref-ref-12.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/ref-ref-12.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/replaceonchanges-25.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/replaceonchanges-25.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/simple-2.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/simple-2.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/simple-26.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/simple-26.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/simple-invoke-10.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/simple-invoke-10.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/subpackage-2.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/subpackage-2.0.0/build.gradle
@@ -102,7 +102,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/union-18.0.0/build.gradle
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/union-18.0.0/build.gradle
@@ -98,7 +98,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = " "
+                description = $/ /$
 
                 url = "https://example.com"
 

--- a/pkg/codegen/java/build.gradle.template
+++ b/pkg/codegen/java/build.gradle.template
@@ -130,7 +130,7 @@ publishing {
                 inceptionYear = "{{ .ProjectInceptionYear }}"
                 name = "{{ .ProjectName }}"
                 packaging = "jar"
-                description = "{{ .ProjectDescription }}"
+                description = {{ groovyDescription .ProjectDescription }}
 
                 url = "{{ .ProjectURL }}"
 

--- a/pkg/codegen/java/templates_gradle.go
+++ b/pkg/codegen/java/templates_gradle.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	tmplt "text/template"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
@@ -33,12 +34,31 @@ func genGradleProject(
 	}
 	for fileName, template := range templates {
 		var buf bytes.Buffer
-		if err := Template(fileName, template).Execute(&buf, ctx); err != nil {
+		if err := gradleTemplate(fileName, template).Execute(&buf, ctx); err != nil {
 			return err
 		}
 		files.add(fileName, buf.Bytes())
 	}
 	return nil
+}
+
+func gradleTemplate(name string, text string) *tmplt.Template {
+	funcs := tmplt.FuncMap{
+		"groovyDescription": formatGroovyDescriptionLiteral,
+	}
+	for k, v := range predefinedFunctions {
+		funcs[k] = v
+	}
+	return tmplt.Must(tmplt.New(name).Funcs(funcs).Option(MissingKeyErrorOption).Parse(text))
+}
+
+// formatGroovyDescriptionLiteral renders s as a Groovy dollar-slashy string
+// literal ($/.../$) suitable for assignment in generated build.gradle files.
+// Dollar-slashy strings are non-interpolating and preserve newlines and quotes
+// without escaping. The only special sequence is "/$", which must be written
+// as "/$/".
+func formatGroovyDescriptionLiteral(s string) string {
+	return "$/" + strings.ReplaceAll(s, "/$", "/$/") + "/$"
 }
 
 func gradleValidatePackage(pkg *schema.Package) error {

--- a/pkg/codegen/java/templates_gradle_test.go
+++ b/pkg/codegen/java/templates_gradle_test.go
@@ -161,6 +161,72 @@ func eksExample() (*schema.Package, *PackageInfo) {
 	return pkg, info
 }
 
+func TestFormatGroovyDescriptionLiteral(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain text",
+			input:    "Pulumi Amazon Web Services (AWS) EKS Components.",
+			expected: "$/Pulumi Amazon Web Services (AWS) EKS Components./$",
+		},
+		{
+			name:     "dollar sign is literal",
+			input:    "cost is $5",
+			expected: "$/cost is $5/$",
+		},
+		{
+			name: "multiline with quotes and backticks",
+			input: `A provider.
+Use the ` + "`Thing`" + ` resource for stuff.
+Line three with "quotes".`,
+			expected: `$/A provider.
+Use the ` + "`Thing`" + ` resource for stuff.
+Line three with "quotes"./$`,
+		},
+		{
+			name:     "slash-dollar escape",
+			input:    "ends with /$",
+			expected: "$/ends with /$//$",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, formatGroovyDescriptionLiteral(tc.input))
+		})
+	}
+}
+
+func TestGenGradleProjectMultilineDescription(t *testing.T) {
+	version := semver.MustParse("1.0.0")
+	pkg := &schema.Package{
+		Name:        "example",
+		Homepage:    "https://pulumi.com",
+		License:     "Apache-2.0",
+		Repository:  "https://github.com/pulumi/pulumi-example",
+		Description: "A provider.\nUse the `MyResource` resource for stuff.\nLine three with \"quotes\".",
+		Version:     &version,
+	}
+	info := &PackageInfo{
+		Dependencies: map[string]string{
+			"com.pulumi:pulumi": "0.1.0",
+		},
+	}
+
+	files := fs{}
+	err := genGradleProject(pkg, info, files, false /*legacyBuildFiles*/)
+	require.NoError(t, err)
+
+	fp := filepath.Join("testdata", "gen-gradle-project-multiline-description", "build.gradle")
+	assertFileContentIs(t, fp, string(files["build.gradle"]))
+}
+
 func TestIsPublishedByPulumi(t *testing.T) {
 	type testCase struct {
 		publisher string

--- a/pkg/codegen/java/testdata/gen-gradle-project-legacy-false/build.gradle
+++ b/pkg/codegen/java/testdata/gen-gradle-project-legacy-false/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-eks"
                 packaging = "jar"
-                description = "Pulumi Amazon Web Services (AWS) EKS Components."
+                description = $/Pulumi Amazon Web Services (AWS) EKS Components./$
 
                 url = "https://github.com/pulumi/pulumi-eks"
 

--- a/pkg/codegen/java/testdata/gen-gradle-project-legacy-true/build.gradle
+++ b/pkg/codegen/java/testdata/gen-gradle-project-legacy-true/build.gradle
@@ -94,7 +94,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-eks"
                 packaging = "jar"
-                description = "Pulumi Amazon Web Services (AWS) EKS Components."
+                description = $/Pulumi Amazon Web Services (AWS) EKS Components./$
 
                 url = "https://github.com/pulumi/pulumi-eks"
 

--- a/pkg/codegen/java/testdata/gen-gradle-project-multiline-description/build.gradle
+++ b/pkg/codegen/java/testdata/gen-gradle-project-multiline-description/build.gradle
@@ -12,7 +12,7 @@ group = "com.pulumi"
 
 def resolvedVersion = System.getenv("PACKAGE_VERSION") ?:
     (project.version == "unspecified"
-         ? "0.0.1"
+         ? "1.0.0"
          : project.version)
 
 def signingKey = System.getenv("SIGNING_KEY")
@@ -43,9 +43,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("com.google.code.gson:gson:2.8.9")
-    implementation("com.pulumi:pulumi:0.0.1")
+    implementation("com.pulumi:pulumi:0.1.0")
 }
 
 task sourcesJar(type: Jar) {
@@ -69,7 +67,7 @@ def genPulumiResources = tasks.register('genPulumiResources') {
         def builder = new groovy.json.JsonBuilder()
         builder {
             resource true
-            name "azure-native"
+            name "example"
             version resolvedVersion
         }
         def infoJson = builder.toPrettyString()
@@ -85,38 +83,40 @@ publishing {
     publications {
         mainPublication(MavenPublication) {
             groupId = "com.pulumi"
-            artifactId = "azure-native"
+            artifactId = "example"
             version = resolvedVersion
             from components.java
             artifact sourcesJar
             artifact javadocJar
 
             pom {
-                inceptionYear = ""
-                name = ""
+                inceptionYear = "2022"
+                name = "pulumi-example"
                 packaging = "jar"
-                description = $/test description/$
+                description = $/A provider.
+Use the `MyResource` resource for stuff.
+Line three with "quotes"./$
 
-                url = "https://github.com/pulumi/pulumi-java"
+                url = "https://github.com/pulumi/pulumi-example"
 
                 scm {
-                    connection = "git@github.com/pulumi/pulumi-java.git"
-                    developerConnection = "git@github.com/pulumi/pulumi-java.git"
-                    url = "https://github.com/pulumi/pulumi-java"
+                    connection = "git@github.com/pulumi/pulumi-example.git"
+                    developerConnection = "git@github.com/pulumi/pulumi-example.git"
+                    url = "https://github.com/pulumi/pulumi-example"
                 }
 
                 licenses {
                     license {
-                        name = ""
-                        url = ""
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
                     }
                 }
 
                 developers {
                     developer {
-                        id = ""
-                        name = ""
-                        email = ""
+                        id = "pulumi"
+                        name = "Pulumi"
+                        email = "support@pulumi.com"
                     }
                 }
             }

--- a/pkg/codegen/testing/test/testdata/akamai/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/akamai/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-akamai"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/assets-and-archives/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/assets-and-archives/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/azure-native-nested-types/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/azure-native-nested-types/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-azure-native"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/build-files/gradle-nexus/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/build-files/gradle-nexus/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-example"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/build-files/gradle/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/build-files/gradle/java/build.gradle
@@ -94,7 +94,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-example"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/build-files/unspecified/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/build-files/unspecified/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-example"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/config-variables/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/config-variables/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/cyclic-types/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/cyclic-types/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/dash-named-schema/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/dash-named-schema/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/dashed-import-schema/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/dashed-import-schema/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/docs-collision/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/docs-collision/java/build.gradle
@@ -92,7 +92,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/embedded-crd-types/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/embedded-crd-types/java/build.gradle
@@ -88,7 +88,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = ""
+                description = $/$/
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/external-enum/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/external-enum/java/build.gradle
@@ -87,7 +87,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = ""
+                description = $/$/
 
                 url = ""
 

--- a/pkg/codegen/testing/test/testdata/functions-secrets/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/functions-secrets/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/hyphenated-symbols/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/hyphenated-symbols/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/jumbo-resources/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/jumbo-resources/java/build.gradle
@@ -99,7 +99,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-kubernetes"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/legacy-names/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/legacy-names/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/mini-awsclassic/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/mini-awsclassic/java/build.gradle
@@ -99,7 +99,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/mini-awsnative/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/mini-awsnative/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/mini-awsx/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/mini-awsx/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/mini-azuread/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/mini-azuread/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/mini-kubernetes/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/mini-kubernetes/java/build.gradle
@@ -99,7 +99,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/naming-collisions/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/naming-collisions/java/build.gradle
@@ -87,7 +87,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = ""
+                description = $/$/
 
                 url = ""
 

--- a/pkg/codegen/testing/test/testdata/nested-module-thirdparty/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/nested-module-thirdparty/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/nested-module/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/nested-module/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/other-owned/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/other-owned/java/build.gradle
@@ -96,7 +96,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/output-funcs-edgeorder/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/output-funcs-tfbridge20/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/output-funcs/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/output-funcs/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/parameterized/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/parameterized/java/build.gradle
@@ -100,7 +100,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/plain-additional-items/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/plain-additional-items/java/build.gradle
@@ -91,7 +91,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/plain-and-default/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/regress-go-10527/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/regress-go-10527/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/regress-go-12971/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/regress-go-12971/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/regress-go-15478/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/regress-go-15478/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/regress-py-12980/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/regress-py-12980/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/regress-py-tfbridge-611/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/replace-on-change/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/replace-on-change/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/resource-args-python-case-insensitive/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/resource-args-python/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/resource-args-python/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/resource-property-overlap/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/resource-property-overlap/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/secrets/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/secrets/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-enum-schema/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-enum-schema/java/build.gradle
@@ -99,7 +99,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema-with-root-package/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-plain-schema/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-plain-schema/java/build.gradle
@@ -99,7 +99,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema-custom-pypackage-name/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-schema/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-resource-schema/java/build.gradle
@@ -96,7 +96,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-resource-with-aliases/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-schema-pyproject/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-schema-pyproject/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = "2022"
                 name = "pulumi-example"
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/simple-yaml-schema/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/simple-yaml-schema/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/unions-inline/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/unions-inline/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/unions-inside-arrays/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/unions-inside-arrays/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/urn-id-properties/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/urn-id-properties/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 

--- a/pkg/codegen/testing/test/testdata/using-shared-types-in-config/java/build.gradle
+++ b/pkg/codegen/testing/test/testdata/using-shared-types-in-config/java/build.gradle
@@ -95,7 +95,7 @@ publishing {
                 inceptionYear = ""
                 name = ""
                 packaging = "jar"
-                description = "test description"
+                description = $/test description/$
 
                 url = "https://github.com/pulumi/pulumi-java"
 


### PR DESCRIPTION
## Summary

Generated Java `build.gradle` files now emit package descriptions as Groovy dollar-slashy string literals (`$/.../$`) instead of raw double-quoted strings. Multi-line descriptions, embedded double quotes, backticks, and dollar signs produce valid Gradle POM metadata without provider-side `sed`/`perl` fixups. Verified locally with `TestFormatGroovyDescriptionLiteral`, `TestGenGradleProjectMultilineDescription`, and a Gradle parse of the multiline golden `build.gradle`.

Part of #2211
Part of pulumi/home#4787

Made with [Cursor](https://cursor.com)