### PR TITLE
Have Renovate write changelog fragments for its updates

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -11,6 +11,11 @@ kinds:
 - label: Bug Fixes
   auto: patch
   key: bug-fixes
+- label: Dependencies
+  auto: patch
+  key: dependencies
+  changeFormat: '- [{{.Component}}] {{.Body}}'
+  skipGlobalChoices: true
 # Custom fragment file format because we use / in the component name.
 fragmentFileFormat: '{{.Kind}}-{{.Custom.PR}}'
 components:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ All commands assume you're at the repo root.
 - Java toolchain targets JDK 11 (not 17) — see `sdk/java/pulumi/build.gradle`.
 - SDK version comes from `PULUMI_JAVA_SDK_VERSION` env var (defaults to `0.0.1` locally).
 - Golden file tests in `pkg/codegen/testing/test/testdata/` verify codegen output stability. Update with `PULUMI_ACCEPT=true`.
-- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one.
+- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. The `Dependencies` kind is reserved for automated Renovate updates: a `postUpgradeTasks` hook runs `make renovate` (see `scripts/renovate-changelog.sh`), so those fragments carry no PR number.
 - Two things named "codegen": `pkg/codegen/java/` is the Go generator; `sdk/java/.../com/pulumi/codegen/` is Java runtime helpers used by generated code.
 
 ## Forbidden actions

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,7 @@ clone_examples::
 .PHONY: changelog
 changelog:
 	changie new
+
+.PHONY: renovate
+renovate:
+	./scripts/renovate-changelog.sh "$(DEP)" "$(VERSION)" "$(FILE)"

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,4 +6,16 @@
     ignorePaths: [
         "**/testdata/**",
     ],
+    packageRules: [
+        {
+            description: "Write a changie fragment for each dependency bump",
+            matchPackageNames: ["*"],
+            postUpgradeTasks: {
+                commands: [
+                    "make renovate DEP='{{{depName}}}' VERSION='{{{newVersion}}}' FILE='{{{packageFile}}}'",
+                ],
+                executionMode: "update",
+            },
+        },
+    ],
 }

--- a/scripts/renovate-changelog.sh
+++ b/scripts/renovate-changelog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Generate a changie fragment for a dependency bump that Renovate applied.
+#
+# Invoked as `make renovate DEP=<name> VERSION=<new version> FILE=<package file>` from a
+# renovate postUpgradeTasks hook (see renovate.json5), which fills the arguments from its
+# {{{depName}}}/{{{newVersion}}}/{{{packageFile}}} template variables, once per updated
+# dependency. Only released artifacts get entries: the Go module at the repo root (the
+# language plugin) and the Java SDK under sdk/java/. No-op for anything else (CI,
+# integration tests, test fixtures).
+#
+# Runs before the PR exists, so fragments carry no PR number; the `dependencies` kind in
+# .changie.yaml is formatted accordingly.
+
+set -euo pipefail
+
+dep="$1"
+version="$2"
+file="$3"
+
+case "$file" in
+    go.mod) component=runtime ;;
+    sdk/java/*test*) exit 0 ;;
+    sdk/java/*) component=sdk ;;
+    *) exit 0 ;;
+esac
+
+slug=$(printf '%s-%s' "$dep" "$version" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')
+slug=${slug#-}
+slug=${slug%-}
+
+# Pinned to the changie version in .mise.toml; `go run` because the renovate container
+# has Go but not our mise toolchain.
+go run github.com/miniscruff/changie@v1.24.2 new \
+    --dry-run \
+    --component "$component" \
+    --kind dependencies \
+    --body "Update $dep to $version" \
+    > ".changes/unreleased/dependencies-$slug.yaml"


### PR DESCRIPTION
Java version of https://github.com/pulumi/pulumi-dotnet/pull/1112
