### PR TITLE
[sdk] Parse gRPC messages with a raised protobuf recursion limit

### DIFF
--- a/.changes/unreleased/bug-fixes-2282.yaml
+++ b/.changes/unreleased/bug-fixes-2282.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Parse gRPC messages with a raised protobuf recursion limit, so resources with deeply nested properties no longer abort the whole program with "Protocol message had too many levels of nesting"
+time: 2026-08-18T12:00:00.000000000Z
+custom:
+    PR: "2282"

--- a/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/GrpcEngine.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/GrpcEngine.java
@@ -2,6 +2,7 @@ package com.pulumi.deployment.internal;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.pulumi.core.internal.ContextAwareCompletableFuture;
+import com.pulumi.internal.GrpcRecursionLimit;
 import io.grpc.ManagedChannelBuilder;
 import pulumirpc.EngineGrpc;
 import pulumirpc.EngineOuterClass.GetRootResourceRequest;
@@ -25,7 +26,8 @@ public class GrpcEngine implements Engine {
         var channelBuilder = ManagedChannelBuilder
                 .forTarget(engine)
                 .usePlaintext() // disable TLS
-                .maxInboundMessageSize(maxRpcMessageSizeInBytes);
+                .maxInboundMessageSize(maxRpcMessageSizeInBytes)
+                .intercept(GrpcRecursionLimit.clientInterceptor());
         var interceptor = Instrumentation.getClientInterceptor();
         if (interceptor != null) {
             channelBuilder.intercept(interceptor);

--- a/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/GrpcMonitor.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/GrpcMonitor.java
@@ -2,6 +2,7 @@ package com.pulumi.deployment.internal;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.pulumi.core.internal.ContextAwareCompletableFuture;
+import com.pulumi.internal.GrpcRecursionLimit;
 import com.pulumi.resources.Resource;
 import io.grpc.ManagedChannelBuilder;
 import pulumirpc.Provider.CallResponse;
@@ -33,7 +34,8 @@ public class GrpcMonitor implements Monitor {
         var channelBuilder = ManagedChannelBuilder
                 .forTarget(monitor)
                 .usePlaintext() // disable TLS
-                .maxInboundMessageSize(maxRpcMessageSizeInBytes);
+                .maxInboundMessageSize(maxRpcMessageSizeInBytes)
+                .intercept(GrpcRecursionLimit.clientInterceptor());
         var interceptor = Instrumentation.getClientInterceptor();
         if (interceptor != null) {
             channelBuilder.intercept(interceptor);

--- a/sdk/java/pulumi/src/main/java/com/pulumi/internal/GrpcRecursionLimit.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/internal/GrpcRecursionLimit.java
@@ -1,0 +1,113 @@
+package com.pulumi.internal;
+
+import com.google.protobuf.Message;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
+import io.grpc.ServerMethodDefinition;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+
+import java.util.ArrayList;
+
+/**
+ * Raises the nesting limit protobuf enforces when Pulumi's gRPC messages are parsed.
+ *
+ * <p>Resource inputs and outputs travel as protobuf {@code Struct}s, and each level of a
+ * user-visible object costs three levels of protobuf nesting: {@code Struct}, map entry,
+ * {@code Value}. Protobuf's Java runtime refuses to parse past 100 levels, and gRPC's default
+ * marshaller keeps that default, so a resource whose schema nests deeply - AWS' recursive
+ * JSON Schema shapes, for instance - fails to deserialize. The failure lands on the channel
+ * rather than the resource, which aborts the whole program instead of one registration.
+ *
+ * <p>The marshallers installed here parse at {@link #RECURSION_LIMIT} instead. Serialization is
+ * left alone: protobuf imposes no depth limit when writing.
+ */
+public final class GrpcRecursionLimit {
+
+    /**
+     * Matches the limit the Go engine parses with, so that the Java SDK is not the narrower end
+     * of the connection.
+     */
+    public static final int RECURSION_LIMIT = 10_000;
+
+    private static final ClientInterceptor CLIENT_INTERCEPTOR = new ClientInterceptor() {
+        @Override
+        public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            return next.newCall(
+                    method.toBuilder()
+                            .setResponseMarshaller(raise(method.getResponseMarshaller()))
+                            .build(),
+                    callOptions);
+        }
+    };
+
+    private GrpcRecursionLimit() {}
+
+    /**
+     * Returns a channel interceptor that parses responses at {@link #RECURSION_LIMIT}.
+     *
+     * @return the interceptor, safe to share between channels
+     */
+    public static ClientInterceptor clientInterceptor() {
+        return CLIENT_INTERCEPTOR;
+    }
+
+    /**
+     * Returns a copy of {@code definition} whose methods parse requests at
+     * {@link #RECURSION_LIMIT}. A {@code ServerInterceptor} cannot do this, because the method
+     * descriptor has already deserialized the request by the time one is consulted.
+     *
+     * @param definition the service to rebind
+     * @return the rebound service, to hand to {@code ServerBuilder.addService}
+     */
+    public static ServerServiceDefinition intercept(ServerServiceDefinition definition) {
+        var original = definition.getServiceDescriptor();
+        var descriptorBuilder = ServiceDescriptor.newBuilder(original.getName())
+                .setSchemaDescriptor(original.getSchemaDescriptor());
+        var methods = new ArrayList<ServerMethodDefinition<?, ?>>();
+        for (var method : definition.getMethods()) {
+            var raised = raiseRequestMarshaller(method);
+            methods.add(raised);
+            descriptorBuilder.addMethod(raised.getMethodDescriptor());
+        }
+        var builder = ServerServiceDefinition.builder(descriptorBuilder.build());
+        for (var method : methods) {
+            builder.addMethod(method);
+        }
+        return builder.build();
+    }
+
+    private static <ReqT, RespT> ServerMethodDefinition<ReqT, RespT> raiseRequestMarshaller(
+            ServerMethodDefinition<ReqT, RespT> method) {
+        var descriptor = method.getMethodDescriptor();
+        return ServerMethodDefinition.create(
+                descriptor.toBuilder()
+                        .setRequestMarshaller(raise(descriptor.getRequestMarshaller()))
+                        .build(),
+                method.getServerCallHandler());
+    }
+
+    /**
+     * Rebuilds a generated protobuf marshaller with the raised limit, or returns it untouched if
+     * it does not expose the prototype needed to do so.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> Marshaller<T> raise(Marshaller<T> marshaller) {
+        if (!(marshaller instanceof PrototypeMarshaller)) {
+            return marshaller;
+        }
+        var prototype = ((PrototypeMarshaller<T>) marshaller).getMessagePrototype();
+        if (!(prototype instanceof Message)) {
+            return marshaller;
+        }
+        return (Marshaller<T>) ProtoUtils.marshallerWithRecursionLimit(
+                (Message) prototype, RECURSION_LIMIT);
+    }
+}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/internal/GrpcRecursionLimit.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/internal/GrpcRecursionLimit.java
@@ -32,7 +32,9 @@ public final class GrpcRecursionLimit {
 
     /**
      * Matches the limit the Go engine parses with, so that the Java SDK is not the narrower end
-     * of the connection.
+     * of the connection. Well above what the JVM can reach in practice: protobuf parses
+     * recursively, so the thread's stack runs out first, somewhere past 300 levels of property
+     * nesting. That makes this a ceiling on the artificial limit rather than on the payload.
      */
     public static final int RECURSION_LIMIT = 10_000;
 

--- a/sdk/java/pulumi/src/main/java/com/pulumi/provider/internal/ResourceProviderService.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/provider/internal/ResourceProviderService.java
@@ -19,6 +19,7 @@ import io.grpc.stub.StreamObserver;
 
 import com.pulumi.core.Alias;
 import com.pulumi.deployment.internal.InlineDeploymentSettings;
+import com.pulumi.internal.GrpcRecursionLimit;
 import com.pulumi.internal.PulumiInternal;
 import com.pulumi.provider.internal.properties.PropertyValue;
 import com.pulumi.resources.ComponentResourceOptions;
@@ -47,7 +48,8 @@ public class ResourceProviderService {
 
     void start() throws IOException {
         server = createServerBuilder()
-            .addService(new ResourceProviderImpl(this.engineAddress, this.implementation))
+            .addService(GrpcRecursionLimit.intercept(
+                new ResourceProviderImpl(this.engineAddress, this.implementation).bindService()))
             .intercept(new ErrorHandlingInterceptor())
             .build()
             .start();

--- a/sdk/java/pulumi/src/test/java/com/pulumi/internal/GrpcRecursionLimitTest.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/internal/GrpcRecursionLimitTest.java
@@ -17,10 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class GrpcRecursionLimitTest {
 
-    // Protobuf stops at 100 levels of nesting by default, and one level of a Struct costs three of
-    // them (Struct, map entry, Value), so this is comfortably past the limit a default marshaller
-    // would enforce. See https://github.com/pulumi/pulumi-java/issues/2277.
-    private static final int NESTING_DEPTH = 64;
+    // Matches the depth of the l2-large-map conformance test (pulumi/pulumi#24361). Protobuf stops
+    // at 100 levels by default and one level of a Struct costs three of them (Struct, map entry,
+    // Value), so a default marshaller gives up around 33. See pulumi/pulumi-java#2277.
+    private static final int NESTING_DEPTH = 300;
 
     private static final String SERVICE_NAME = "pulumirpc.ResourceMonitor";
 

--- a/sdk/java/pulumi/src/test/java/com/pulumi/internal/GrpcRecursionLimitTest.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/internal/GrpcRecursionLimitTest.java
@@ -1,0 +1,99 @@
+package com.pulumi.internal;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import com.pulumi.deployment.internal.GrpcMonitor;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import pulumirpc.Resource.RegisterResourceRequest;
+import pulumirpc.Resource.RegisterResourceResponse;
+import pulumirpc.ResourceMonitorGrpc;
+
+import java.io.ByteArrayInputStream;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GrpcRecursionLimitTest {
+
+    // Protobuf stops at 100 levels of nesting by default, and one level of a Struct costs three of
+    // them (Struct, map entry, Value), so this is comfortably past the limit a default marshaller
+    // would enforce. See https://github.com/pulumi/pulumi-java/issues/2277.
+    private static final int NESTING_DEPTH = 64;
+
+    private static final String SERVICE_NAME = "pulumirpc.ResourceMonitor";
+
+    @Test
+    void monitorParsesDeeplyNestedResponses() throws Exception {
+        var object = nestedStruct(NESTING_DEPTH);
+        var server = ServerBuilder.forPort(0)
+                .addService(new ResourceMonitorGrpc.ResourceMonitorImplBase() {
+                    @Override
+                    public void registerResource(
+                            RegisterResourceRequest request,
+                            StreamObserver<RegisterResourceResponse> responseObserver) {
+                        responseObserver.onNext(RegisterResourceResponse.newBuilder()
+                                .setUrn("urn:pulumi:test::test::test:index:Test::test")
+                                .setObject(object)
+                                .build());
+                        responseObserver.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+        try {
+            var monitor = new GrpcMonitor("127.0.0.1:" + server.getPort());
+            var response = monitor
+                    .registerResourceAsync(null, RegisterResourceRequest.getDefaultInstance())
+                    .get(30, TimeUnit.SECONDS);
+            assertThat(response.getObject()).isEqualTo(object);
+        } finally {
+            server.shutdownNow();
+            server.awaitTermination(30, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void reboundServiceParsesDeeplyNestedRequests() {
+        var request = RegisterResourceRequest.newBuilder()
+                .setObject(nestedStruct(NESTING_DEPTH))
+                .build();
+
+        var service = GrpcRecursionLimit.intercept(
+                new ResourceMonitorGrpc.ResourceMonitorImplBase() {}.bindService());
+        var method = service.getMethod(SERVICE_NAME + "/RegisterResource");
+
+        var parsed = method.getMethodDescriptor().getRequestMarshaller()
+                .parse(new ByteArrayInputStream(request.toByteArray()));
+
+        assertThat(parsed).isEqualTo(request);
+    }
+
+    @Test
+    void reboundServiceKeepsItsMethodsAndHandlers() {
+        var original = new ResourceMonitorGrpc.ResourceMonitorImplBase() {}.bindService();
+        var rebound = GrpcRecursionLimit.intercept(original);
+
+        assertThat(rebound.getServiceDescriptor().getName()).isEqualTo(SERVICE_NAME);
+        assertThat(rebound.getMethods()).hasSameSizeAs(original.getMethods());
+        for (var method : original.getMethods()) {
+            var name = method.getMethodDescriptor().getFullMethodName();
+            assertThat(rebound.getMethod(name)).isNotNull();
+            assertThat(rebound.getMethod(name).getServerCallHandler())
+                    .isSameAs(method.getServerCallHandler());
+        }
+    }
+
+    private static Struct nestedStruct(int depth) {
+        var struct = Struct.newBuilder()
+                .putFields("leaf", Value.newBuilder().setStringValue("bottom").build())
+                .build();
+        for (var i = 0; i < depth; i++) {
+            struct = Struct.newBuilder()
+                    .putFields("nested", Value.newBuilder().setStructValue(struct).build())
+                    .build();
+        }
+        return struct;
+    }
+}


### PR DESCRIPTION
Fixes #2277.

### What happens today

Resource inputs and outputs travel as protobuf `Struct`s, where one level of a user-visible object costs three levels of protobuf nesting: `Struct` -> map entry -> `Value`. Protobuf's Java runtime refuses to parse past 100 levels, so the Java SDK tops out at roughly 33 levels of property nesting.

gRPC's default marshaller keeps that default and, until recently, offered no way to change it (grpc/grpc-java#8256). When a provider returns something deeper - the recursive JSON Schema shapes AWS flattens into long generated type chains, for example - the parse fails on the channel rather than on the resource:

```
io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.
Caused by: io.grpc.StatusRuntimeException: INTERNAL: Invalid protobuf byte sequence
Caused by: com.google.protobuf.InvalidProtocolBufferException:
    Protocol message had too many levels of nesting. May be malicious.
```

Because the failure is on the channel, the whole program aborts: no resource in the stack gets a plan, and no resource is named in the error.

### The fix

grpc-java has exposed `ProtoUtils.marshallerWithRecursionLimit` since 1.56, and this repo is on 1.57.2, so no dependency bump is needed. `GrpcRecursionLimit` rebuilds the generated marshallers with the limit raised to 10,000 - matching what the Go engine parses with, so the Java SDK is no longer the narrower end of the connection - and installs them:

- `GrpcMonitor` and `GrpcEngine` add a channel interceptor that swaps in the raised **response** marshaller. This is the path in the issue.
- `ResourceProviderService` rebinds its service definition so a Java component provider parses deeply nested **requests** too. A `ServerInterceptor` cannot do this: the method descriptor has already deserialized the request by the time one is consulted.

Serialization is untouched - protobuf imposes no depth limit when writing.

### Tests

`GrpcRecursionLimitTest` covers both directions with 64 levels of `Struct` nesting, which is comfortably past the default:

- `monitorParsesDeeplyNestedResponses` runs a real `ResourceMonitor` server over loopback and calls it through `GrpcMonitor`, so it exercises the wiring and a real serialize/parse round trip. (An in-process channel would not reproduce the bug - gRPC hands the message across without serializing it.)
- `reboundServiceParsesDeeplyNestedRequests` and `reboundServiceKeepsItsMethodsAndHandlers` cover the server-side rebind.

I checked that `monitorParsesDeeplyNestedResponses` fails with the original `INTERNAL: Invalid protobuf byte sequence` when the interceptor is removed from `GrpcMonitor`.

### Notes

- 10,000 is a policy choice. Deep enough that the engine's own limit binds first; bounded, because protobuf parses recursively and an unbounded limit trades a clear error for a `StackOverflowError`. Happy to move it if you would rather it were lower.
- This does not add the conformance test @Frassle mentioned in #2277 - that lives in `pulumi/pulumi` - so it is up for grabs alongside this.
