### PR TITLE
Fill in constant property values from the generated args type

### DIFF
--- a/.changes/unreleased/Improvements-2298.yaml
+++ b/.changes/unreleased/Improvements-2298.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: Improvements
+body: 'Generate constant property values into the args type itself, rather than requiring callers to repeat them. Builder setters for constant properties are deprecated, and generated programs no longer set them.'
+time: 2026-09-01T00:00:00.000000000Z
+custom:
+    PR: "2298"

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l2-discriminated-union-many/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l2-discriminated-union-many/src/main/java/generated_program/App.java
@@ -32,7 +32,6 @@ public class App {
     public static void stack(Context ctx) {
         var example1 = new Example("example1", ExampleArgs.builder()
             .unionOf(Variant1Args.builder()
-                .discriminantKind("variant1")
                 .payload("p1")
                 .extra("e1")
                 .build())
@@ -40,7 +39,6 @@ public class App {
 
         var example2 = new Example("example2", ExampleArgs.builder()
             .unionOf(Variant2Args.builder()
-                .discriminantKind("variant2")
                 .payload("p2")
                 .extra("e2")
                 .build())
@@ -48,7 +46,6 @@ public class App {
 
         var example3 = new Example("example3", ExampleArgs.builder()
             .unionOf(Variant3Args.builder()
-                .discriminantKind("variant3")
                 .payload("p3")
                 .count(3)
                 .build())
@@ -56,7 +53,6 @@ public class App {
 
         var example4 = new Example("example4", ExampleArgs.builder()
             .unionOf(Variant4Args.builder()
-                .discriminantKind("variant4")
                 .payload("p4")
                 .enabled(true)
                 .build())
@@ -64,7 +60,6 @@ public class App {
 
         var example5 = new Example("example5", ExampleArgs.builder()
             .unionOf(Variant5Args.builder()
-                .discriminantKind("variant5")
                 .payload("p5")
                 .label("l5")
                 .build())
@@ -72,7 +67,6 @@ public class App {
 
         var example6 = new Example("example6", ExampleArgs.builder()
             .unionOf(Variant6Args.builder()
-                .discriminantKind("variant6")
                 .payload("p6")
                 .code(6)
                 .build())
@@ -80,7 +74,6 @@ public class App {
 
         var example7 = new Example("example7", ExampleArgs.builder()
             .unionOf(Variant7Args.builder()
-                .discriminantKind("variant7")
                 .payload("p7")
                 .message("m7")
                 .build())
@@ -88,7 +81,6 @@ public class App {
 
         var example8 = new Example("example8", ExampleArgs.builder()
             .unionOf(Variant8Args.builder()
-                .discriminantKind("variant8")
                 .payload("p8")
                 .size(8)
                 .build())
@@ -96,7 +88,6 @@ public class App {
 
         var example9 = new Example("example9", ExampleArgs.builder()
             .unionOf(Variant9Args.builder()
-                .discriminantKind("variant9")
                 .payload("p9")
                 .flag(false)
                 .build())
@@ -104,7 +95,6 @@ public class App {
 
         var example10 = new Example("example10", ExampleArgs.builder()
             .unionOf(Variant10Args.builder()
-                .discriminantKind("variant10")
                 .payload("p10")
                 .note("n10")
                 .build())
@@ -115,7 +105,6 @@ public class App {
         // full 10-variant union.
         var subset1 = new SubsetExample("subset1", SubsetExampleArgs.builder()
             .unionOf(Variant3Args.builder()
-                .discriminantKind("variant3")
                 .payload("sp")
                 .count(33)
                 .build())

--- a/pkg/cmd/pulumi-language-java/testdata/projects/l2-resource-const/src/main/java/generated_program/App.java
+++ b/pkg/cmd/pulumi-language-java/testdata/projects/l2-resource-const/src/main/java/generated_program/App.java
@@ -18,9 +18,7 @@ public class App {
     }
 
     public static void stack(Context ctx) {
-        var first = new Resource("first", ResourceArgs.builder()
-            .kind("Constant")
-            .build());
+        var first = new Resource("first");
 
         ctx.export("kind", first.kind());
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/constant-43.0.0/src/main/java/com/pulumi/constant/Resource.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/constant-43.0.0/src/main/java/com/pulumi/constant/Resource.java
@@ -51,15 +51,12 @@ public class Resource extends com.pulumi.resources.CustomResource {
         super("constant:index:Resource", name, null, makeResourceOptions(options, id), false);
     }
 
-    @SuppressWarnings("deprecation")
     private static ResourceArgs makeArgs(ResourceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }
         var builder = args == null ? ResourceArgs.builder() : ResourceArgs.builder(args);
-        return builder
-            .kind("Constant")
-            .build();
+        return builder.build();
     }
 
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/constant-43.0.0/src/main/java/com/pulumi/constant/Resource.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/constant-43.0.0/src/main/java/com/pulumi/constant/Resource.java
@@ -51,6 +51,7 @@ public class Resource extends com.pulumi.resources.CustomResource {
         super("constant:index:Resource", name, null, makeResourceOptions(options, id), false);
     }
 
+    @SuppressWarnings("deprecation")
     private static ResourceArgs makeArgs(ResourceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/constant-43.0.0/src/main/java/com/pulumi/constant/ResourceArgs.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/constant-43.0.0/src/main/java/com/pulumi/constant/ResourceArgs.java
@@ -46,17 +46,33 @@ public final class ResourceArgs extends com.pulumi.resources.ResourceArgs {
             $ = new ResourceArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(Output<String> kind) {
             $.kind = kind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(String kind) {
             return kind(Output.of(kind));
         }
 
         public ResourceArgs build() {
-            $.kind = Codegen.stringProp("kind").output().arg($.kind).require();
+            $.kind = Codegen.stringProp("kind").output().arg($.kind).def("Constant").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant10Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant10Args.java
@@ -64,11 +64,27 @@ public final class Variant10Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant10Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -92,7 +108,7 @@ public final class Variant10Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant10Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant10").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant1Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant1Args.java
@@ -64,11 +64,27 @@ public final class Variant1Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant1Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -92,7 +108,7 @@ public final class Variant1Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant1Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant1").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant2Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant2Args.java
@@ -64,11 +64,27 @@ public final class Variant2Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant2Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -92,7 +108,7 @@ public final class Variant2Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant2Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant2").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant3Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant3Args.java
@@ -74,11 +74,27 @@ public final class Variant3Args extends com.pulumi.resources.ResourceArgs {
             return count(Output.of(count));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -93,7 +109,7 @@ public final class Variant3Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant3Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant3").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant4Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant4Args.java
@@ -65,11 +65,27 @@ public final class Variant4Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant4Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -93,7 +109,7 @@ public final class Variant4Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant4Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant4").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant5Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant5Args.java
@@ -64,11 +64,27 @@ public final class Variant5Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant5Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -92,7 +108,7 @@ public final class Variant5Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant5Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant5").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant6Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant6Args.java
@@ -74,11 +74,27 @@ public final class Variant6Args extends com.pulumi.resources.ResourceArgs {
             return code(Output.of(code));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -93,7 +109,7 @@ public final class Variant6Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant6Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant6").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant7Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant7Args.java
@@ -64,11 +64,27 @@ public final class Variant7Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant7Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -92,7 +108,7 @@ public final class Variant7Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant7Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant7").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant8Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant8Args.java
@@ -65,11 +65,27 @@ public final class Variant8Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant8Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -93,7 +109,7 @@ public final class Variant8Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant8Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant8").require();
             return $;
         }
     }

--- a/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant9Args.java
+++ b/pkg/cmd/pulumi-language-java/testdata/sdks/discriminated-union-many-49.0.0/src/main/java/com/pulumi/discriminatedunionmany/inputs/Variant9Args.java
@@ -65,11 +65,27 @@ public final class Variant9Args extends com.pulumi.resources.ResourceArgs {
             $ = new Variant9Args(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(Output<String> discriminantKind) {
             $.discriminantKind = discriminantKind;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder discriminantKind(String discriminantKind) {
             return discriminantKind(Output.of(discriminantKind));
         }
@@ -93,7 +109,7 @@ public final class Variant9Args extends com.pulumi.resources.ResourceArgs {
         }
 
         public Variant9Args build() {
-            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).require();
+            $.discriminantKind = Codegen.stringProp("discriminantKind").output().arg($.discriminantKind).def("variant9").require();
             return $;
         }
     }

--- a/pkg/codegen/java/gen.go
+++ b/pkg/codegen/java/gen.go
@@ -411,7 +411,13 @@ type propJavadocOptions struct {
 func genPropJavadoc(ctx *classFileContext, prop *schema.Property, options propJavadocOptions) {
 	w := ctx.writer
 
-	if prop.Comment == "" && prop.DeprecationMessage == "" {
+	deprecationMessage := prop.DeprecationMessage
+	if options.isBuilder && prop.ConstValue != nil && deprecationMessage == "" {
+		// The generated type supplies the constant itself, so the setter is redundant.
+		deprecationMessage = "This property has a constant value, which is set automatically."
+	}
+
+	if prop.Comment == "" && deprecationMessage == "" {
 		return
 	}
 	fprintf(w, "%s/**\n", options.indent)
@@ -434,12 +440,12 @@ func genPropJavadoc(ctx *classFileContext, prop *schema.Property, options propJa
 		fprintf(w, "%s\n", formatBlockComment("@return builder", options.indent))
 	}
 
-	if prop.DeprecationMessage != "" {
+	if deprecationMessage != "" {
 		fprintf(w, "%s * @deprecated\n", options.indent)
-		fprintf(w, "%s\n", formatForeignBlockComment(prop.DeprecationMessage, options.indent))
+		fprintf(w, "%s\n", formatForeignBlockComment(deprecationMessage, options.indent))
 	}
 	fprintf(w, "%s */\n", options.indent)
-	printObsoleteAttribute(ctx, prop.DeprecationMessage, options.indent)
+	printObsoleteAttribute(ctx, deprecationMessage, options.indent)
 }
 
 func (pt *plainType) genInputProperty(ctx *classFileContext, prop *schema.Property, targetType TypeShape) error {
@@ -1134,6 +1140,10 @@ func (mod *modContext) genResource(ctx *classFileContext, r *schema.Resource, ar
 
 	// Write the method that will calculate the resource arguments.
 	fprintf(w, "\n")
+	if hasConstInputs {
+		// Const setters are deprecated for callers, but this is how the constant gets forced.
+		fprintf(w, "    @SuppressWarnings(\"deprecation\")\n")
+	}
 	fprintf(w, "    private static %s makeArgs(%s args, @%s %s options) {\n",
 		ctx.ref(argsFQN), argsType, ctx.ref(names.Nullable), optionsType)
 	fprintf(w,

--- a/pkg/codegen/java/gen.go
+++ b/pkg/codegen/java/gen.go
@@ -412,9 +412,10 @@ func genPropJavadoc(ctx *classFileContext, prop *schema.Property, options propJa
 	w := ctx.writer
 
 	deprecationMessage := prop.DeprecationMessage
-	if options.isBuilder && prop.ConstValue != nil && deprecationMessage == "" {
+	if options.isBuilder && prop.ConstValue != nil {
 		// The generated type supplies the constant itself, so the setter is redundant.
-		deprecationMessage = "This property has a constant value, which is set automatically."
+		deprecationMessage = strings.TrimSpace(deprecationMessage +
+			" This property has a constant value, which is set automatically.")
 	}
 
 	if prop.Comment == "" && deprecationMessage == "" {
@@ -1140,10 +1141,6 @@ func (mod *modContext) genResource(ctx *classFileContext, r *schema.Resource, ar
 
 	// Write the method that will calculate the resource arguments.
 	fprintf(w, "\n")
-	if hasConstInputs {
-		// Const setters are deprecated for callers, but this is how the constant gets forced.
-		fprintf(w, "    @SuppressWarnings(\"deprecation\")\n")
-	}
 	fprintf(w, "    private static %s makeArgs(%s args, @%s %s options) {\n",
 		ctx.ref(argsFQN), argsType, ctx.ref(names.Nullable), optionsType)
 	fprintf(w,
@@ -1153,20 +1150,10 @@ func (mod *modContext) genResource(ctx *classFileContext, r *schema.Resource, ar
 	fprintf(w,
 		"        }\n")
 	if hasConstInputs {
+		// build() fills in the constant values, which Empty does not carry.
 		fprintf(w,
 			"        var builder = args == null ? %[1]s.builder() : %[1]s.builder(args);\n", ctx.ref(argsFQN))
-		fprintf(w, "        return builder\n")
-		for _, prop := range r.InputProperties {
-			if prop.ConstValue != nil {
-				v, _, err := primitiveValue(prop.ConstValue)
-				if err != nil {
-					return err
-				}
-				setterName := names.Ident(mod.propertyName(prop)).AsProperty().Setter()
-				fprintf(w, "            .%s(%s)\n", setterName, v)
-			}
-		}
-		fprintf(w, "            .build();\n")
+		fprintf(w, "        return builder.build();\n")
 	} else {
 		fprintf(w,
 			"        return args == null ? %s.Empty : args;\n", ctx.ref(argsFQN))

--- a/pkg/codegen/java/gen_defaults.go
+++ b/pkg/codegen/java/gen_defaults.go
@@ -17,9 +17,6 @@ import (
 	"github.com/pulumi/pulumi-java/pkg/codegen/java/names"
 )
 
-// TODO would this file be a convenient place to handle
-// DefaultValue.ConstValue also?
-
 // Helper type for config getter and default value generation. Use
 // configExpr and defaultValueExpr, the rest are helper methods.
 type defaultsGen struct {
@@ -202,6 +199,20 @@ func (dg *defaultsGen) builderExprWithSimpleType(
 
 	if arg != "" {
 		fmt.Fprintf(&buf, ".arg(%s)", arg)
+	}
+
+	// A constant property only ever holds one value, so fill it in rather than making the caller
+	// repeat it. A value the caller passed still wins, through .arg above.
+	if prop.ConstValue != nil {
+		primCode, primType, err := primitiveValue(prop.ConstValue)
+		if err != nil {
+			return "", err
+		}
+		if !primType.WithoutAnnotations().Equal(targetType.WithoutAnnotations()) {
+			return "", fmt.Errorf("Const value type mismatch: %v vs %v", primType, targetType)
+		}
+		fmt.Fprintf(&buf, ".def(%s)", primCode)
+		return buf.String(), nil
 	}
 
 	if prop.DefaultValue == nil {

--- a/pkg/codegen/java/gen_program.go
+++ b/pkg/codegen/java/gen_program.go
@@ -1415,6 +1415,19 @@ func typedResourceProperties(resource *pcl.Resource) map[string]schema.Type {
 	return resourceProperties
 }
 
+// Returns the set of property names that the schema pins to a constant value. Generated args types
+// supply these values themselves, and their setters are deprecated, so programs must not set them.
+func constPropertyNames(properties []*schema.Property) map[string]bool {
+	constProperties := map[string]bool{}
+	for _, property := range properties {
+		if property.ConstValue != nil {
+			constProperties[property.Name] = true
+		}
+	}
+
+	return constProperties
+}
+
 func (g *generator) genResource(w io.Writer, resource *pcl.Resource) {
 	resourceTypeName := g.resourceTypeName(resource)
 	resourceArgs := g.resourceArgsTypeName(resource)
@@ -1439,11 +1452,22 @@ func (g *generator) genResource(w io.Writer, resource *pcl.Resource) {
 		}
 	}
 
+	inputs := make([]*model.Attribute, 0, len(resource.Inputs))
+	constProperties := map[string]bool{}
+	if resource.Schema != nil {
+		constProperties = constPropertyNames(resource.Schema.InputProperties)
+	}
+	for _, input := range resource.Inputs {
+		if !constProperties[input.Name] {
+			inputs = append(inputs, input)
+		}
+	}
+
 	instantiate := func(resName string) {
 		resourceProperties := typedResourceProperties(resource)
-		if len(resource.Inputs) == 0 && !hasCustomResourceOptions(resource) {
+		if len(inputs) == 0 && !hasCustomResourceOptions(resource) {
 			g.Fgenf(w, "new %s(%s)", resourceTypeName, resName)
-		} else if len(resource.Inputs) == 0 && hasCustomResourceOptions(resource) {
+		} else if len(inputs) == 0 && hasCustomResourceOptions(resource) {
 			// generate empty resource args in this case
 			emptyArgs := resourceArgs + ".Empty"
 			g.Fgenf(w, "new %s(%s, %s, ", resourceTypeName, resName, emptyArgs)
@@ -1453,7 +1477,7 @@ func (g *generator) genResource(w io.Writer, resource *pcl.Resource) {
 			g.Fgenf(w, "new %s(%s, %s.builder()", resourceTypeName, resName, resourceArgs)
 			g.Fgen(w, "\n")
 			g.Indented(func() {
-				for _, attr := range resource.Inputs {
+				for _, attr := range inputs {
 					attributeIdent := names.MakeValidIdentifier(attr.Name)
 					attributeSchemaType := resourceProperties[attr.Name]
 					g.currentResourcePropertyType = attributeSchemaType

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -784,11 +784,16 @@ func (g *generator) genObjectConsExpressionWithTypeName(
 			destTypeName = fq
 		}
 
+		constProperties := constPropertyNames(destType.Properties)
+
 		g.Fgenf(w, "%s.builder()", destTypeName)
 		g.genNewline(w)
 		g.Indented(func() {
 			for _, item := range expr.Items {
 				lit := item.Key.(*model.LiteralValueExpression)
+				if constProperties[lit.Value.AsString()] {
+					continue
+				}
 				key := names.MakeValidIdentifier(names.LowerCamelCase(lit.Value.AsString()))
 				attributeType := objectProperties[lit.Value.AsString()]
 				g.genIndent(w)

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMap.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMap.java
@@ -135,16 +135,12 @@ public class ConfigMap extends com.pulumi.resources.CustomResource {
         super("kubernetes:core/v1:ConfigMap", name, null, makeResourceOptions(options, id), false);
     }
 
-    @SuppressWarnings("deprecation")
     private static ConfigMapArgs makeArgs(@Nullable ConfigMapArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }
         var builder = args == null ? ConfigMapArgs.builder() : ConfigMapArgs.builder(args);
-        return builder
-            .apiVersion("v1")
-            .kind("ConfigMap")
-            .build();
+        return builder.build();
     }
 
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMap.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMap.java
@@ -135,6 +135,7 @@ public class ConfigMap extends com.pulumi.resources.CustomResource {
         super("kubernetes:core/v1:ConfigMap", name, null, makeResourceOptions(options, id), false);
     }
 
+    @SuppressWarnings("deprecation")
     private static ConfigMapArgs makeArgs(@Nullable ConfigMapArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapArgs.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapArgs.java
@@ -143,7 +143,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder apiVersion(@Nullable Output<String> apiVersion) {
             $.apiVersion = apiVersion;
             return this;
@@ -154,7 +158,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder apiVersion(String apiVersion) {
             return apiVersion(Output.of(apiVersion));
         }
@@ -227,7 +235,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(@Nullable Output<String> kind) {
             $.kind = kind;
             return this;
@@ -238,7 +250,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(String kind) {
             return kind(Output.of(kind));
         }
@@ -265,8 +281,8 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ConfigMapArgs build() {
-            $.apiVersion = Codegen.stringProp("apiVersion").output().arg($.apiVersion).getNullable();
-            $.kind = Codegen.stringProp("kind").output().arg($.kind).getNullable();
+            $.apiVersion = Codegen.stringProp("apiVersion").output().arg($.apiVersion).def("v1").getNullable();
+            $.kind = Codegen.stringProp("kind").output().arg($.kind).def("ConfigMap").getNullable();
             return $;
         }
     }

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapList.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapList.java
@@ -107,6 +107,7 @@ public class ConfigMapList extends com.pulumi.resources.CustomResource {
         super("kubernetes:core/v1:ConfigMapList", name, null, makeResourceOptions(options, id), false);
     }
 
+    @SuppressWarnings("deprecation")
     private static ConfigMapListArgs makeArgs(ConfigMapListArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapList.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapList.java
@@ -107,16 +107,12 @@ public class ConfigMapList extends com.pulumi.resources.CustomResource {
         super("kubernetes:core/v1:ConfigMapList", name, null, makeResourceOptions(options, id), false);
     }
 
-    @SuppressWarnings("deprecation")
     private static ConfigMapListArgs makeArgs(ConfigMapListArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }
         var builder = args == null ? ConfigMapListArgs.builder() : ConfigMapListArgs.builder(args);
-        return builder
-            .apiVersion("v1")
-            .kind("ConfigMapList")
-            .build();
+        return builder.build();
     }
 
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapListArgs.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/ConfigMapListArgs.java
@@ -112,7 +112,11 @@ public final class ConfigMapListArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder apiVersion(@Nullable Output<String> apiVersion) {
             $.apiVersion = apiVersion;
             return this;
@@ -123,7 +127,11 @@ public final class ConfigMapListArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder apiVersion(String apiVersion) {
             return apiVersion(Output.of(apiVersion));
         }
@@ -164,7 +172,11 @@ public final class ConfigMapListArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(@Nullable Output<String> kind) {
             $.kind = kind;
             return this;
@@ -175,7 +187,11 @@ public final class ConfigMapListArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(String kind) {
             return kind(Output.of(kind));
         }
@@ -202,11 +218,11 @@ public final class ConfigMapListArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ConfigMapListArgs build() {
-            $.apiVersion = Codegen.stringProp("apiVersion").output().arg($.apiVersion).getNullable();
+            $.apiVersion = Codegen.stringProp("apiVersion").output().arg($.apiVersion).def("v1").getNullable();
             if ($.items == null) {
                 throw new MissingRequiredPropertyException("ConfigMapListArgs", "items");
             }
-            $.kind = Codegen.stringProp("kind").output().arg($.kind).getNullable();
+            $.kind = Codegen.stringProp("kind").output().arg($.kind).def("ConfigMapList").getNullable();
             return $;
         }
     }

--- a/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/inputs/ConfigMapArgs.java
+++ b/pkg/codegen/testing/test/testdata/kubernetes20/java/src/main/java/com/pulumi/kubernetes/core/v1/inputs/ConfigMapArgs.java
@@ -147,7 +147,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder apiVersion(@Nullable Output<String> apiVersion) {
             $.apiVersion = apiVersion;
             return this;
@@ -158,7 +162,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder apiVersion(String apiVersion) {
             return apiVersion(Output.of(apiVersion));
         }
@@ -231,7 +239,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(@Nullable Output<String> kind) {
             $.kind = kind;
             return this;
@@ -242,7 +254,11 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
          * 
          * @return builder
          * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
          */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder kind(String kind) {
             return kind(Output.of(kind));
         }
@@ -269,8 +285,8 @@ public final class ConfigMapArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public ConfigMapArgs build() {
-            $.apiVersion = Codegen.stringProp("apiVersion").output().arg($.apiVersion).getNullable();
-            $.kind = Codegen.stringProp("kind").output().arg($.kind).getNullable();
+            $.apiVersion = Codegen.stringProp("apiVersion").output().arg($.apiVersion).def("v1").getNullable();
+            $.kind = Codegen.stringProp("kind").output().arg($.kind).def("ConfigMap").getNullable();
             return $;
         }
     }

--- a/pkg/codegen/testing/test/testdata/mini-azurenative/java/src/main/java/com/pulumi/azurenative/insights/WebTest.java
+++ b/pkg/codegen/testing/test/testdata/mini-azurenative/java/src/main/java/com/pulumi/azurenative/insights/WebTest.java
@@ -250,7 +250,8 @@ public class WebTest extends com.pulumi.resources.CustomResource {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }
-        return args == null ? WebTestArgs.Empty : args;
+        var builder = args == null ? WebTestArgs.builder() : WebTestArgs.builder(args);
+        return builder.build();
     }
 
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {

--- a/pkg/codegen/testing/test/testdata/mini-azurenative/java/src/main/java/com/pulumi/azurenative/insights/WebTestArgs.java
+++ b/pkg/codegen/testing/test/testdata/mini-azurenative/java/src/main/java/com/pulumi/azurenative/insights/WebTestArgs.java
@@ -201,6 +201,29 @@ public final class WebTestArgs extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.webTestName);
     }
 
+    /**
+     * The type of this WebTest.
+     * 
+     * @deprecated
+     * webTestType is no longer used.
+     * 
+     */
+    @Deprecated /* webTestType is no longer used. */
+    @Import(name="webTestType")
+    private @Nullable Output<String> webTestType;
+
+    /**
+     * @return The type of this WebTest.
+     * 
+     * @deprecated
+     * webTestType is no longer used.
+     * 
+     */
+    @Deprecated /* webTestType is no longer used. */
+    public Optional<Output<String>> webTestType() {
+        return Optional.ofNullable(this.webTestType);
+    }
+
     private WebTestArgs() {}
 
     private WebTestArgs(WebTestArgs $) {
@@ -216,6 +239,7 @@ public final class WebTestArgs extends com.pulumi.resources.ResourceArgs {
         this.timeout = $.timeout;
         this.webTestKind = $.webTestKind;
         this.webTestName = $.webTestName;
+        this.webTestType = $.webTestType;
     }
 
     public static Builder builder() {
@@ -488,6 +512,35 @@ public final class WebTestArgs extends com.pulumi.resources.ResourceArgs {
             return webTestName(Output.of(webTestName));
         }
 
+        /**
+         * @param webTestType The type of this WebTest.
+         * 
+         * @return builder
+         * 
+         * @deprecated
+         * webTestType is no longer used. This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* webTestType is no longer used. This property has a constant value, which is set automatically. */
+        public Builder webTestType(@Nullable Output<String> webTestType) {
+            $.webTestType = webTestType;
+            return this;
+        }
+
+        /**
+         * @param webTestType The type of this WebTest.
+         * 
+         * @return builder
+         * 
+         * @deprecated
+         * webTestType is no longer used. This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* webTestType is no longer used. This property has a constant value, which is set automatically. */
+        public Builder webTestType(String webTestType) {
+            return webTestType(Output.of(webTestType));
+        }
+
         public WebTestArgs build() {
             $.frequency = Codegen.integerProp("frequency").output().arg($.frequency).def(300).getNullable();
             $.kind = Codegen.objectProp("kind", WebTestKind.class).output().arg($.kind).def(WebTestKind.Ping).getNullable();
@@ -499,6 +552,7 @@ public final class WebTestArgs extends com.pulumi.resources.ResourceArgs {
             }
             $.timeout = Codegen.integerProp("timeout").output().arg($.timeout).def(30).getNullable();
             $.webTestKind = Codegen.objectProp("webTestKind", WebTestKind.class).output().arg($.webTestKind).def(WebTestKind.Ping).require();
+            $.webTestType = Codegen.stringProp("webTestType").output().arg($.webTestType).def("standard").getNullable();
             return $;
         }
     }

--- a/pkg/codegen/testing/test/testdata/mini-azurenative/schema.json
+++ b/pkg/codegen/testing/test/testdata/mini-azurenative/schema.json
@@ -267,6 +267,12 @@
         "webTestName": {
           "type": "string",
           "description": "User defined name if this WebTest."
+        },
+        "webTestType": {
+          "type": "string",
+          "description": "The type of this WebTest.",
+          "const": "standard",
+          "deprecationMessage": "webTestType is no longer used."
         }
       },
       "requiredInputs": [

--- a/pkg/codegen/testing/test/testdata/output-funcs/java/src/main/java/com/pulumi/mypkg/inputs/FuncWithConstInputArgs.java
+++ b/pkg/codegen/testing/test/testdata/output-funcs/java/src/main/java/com/pulumi/mypkg/inputs/FuncWithConstInputArgs.java
@@ -47,17 +47,33 @@ public final class FuncWithConstInputArgs extends com.pulumi.resources.InvokeArg
             $ = new FuncWithConstInputArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder plainInput(@Nullable Output<String> plainInput) {
             $.plainInput = plainInput;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder plainInput(String plainInput) {
             return plainInput(Output.of(plainInput));
         }
 
         public FuncWithConstInputArgs build() {
-            $.plainInput = Codegen.stringProp("plainInput").output().arg($.plainInput).getNullable();
+            $.plainInput = Codegen.stringProp("plainInput").output().arg($.plainInput).def("fixed").getNullable();
             return $;
         }
     }

--- a/pkg/codegen/testing/test/testdata/output-funcs/java/src/main/java/com/pulumi/mypkg/inputs/FuncWithConstInputPlainArgs.java
+++ b/pkg/codegen/testing/test/testdata/output-funcs/java/src/main/java/com/pulumi/mypkg/inputs/FuncWithConstInputPlainArgs.java
@@ -46,13 +46,21 @@ public final class FuncWithConstInputPlainArgs extends com.pulumi.resources.Invo
             $ = new FuncWithConstInputPlainArgs(Objects.requireNonNull(defaults));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder plainInput(@Nullable String plainInput) {
             $.plainInput = plainInput;
             return this;
         }
 
         public FuncWithConstInputPlainArgs build() {
-            $.plainInput = Codegen.stringProp("plainInput").arg($.plainInput).getNullable();
+            $.plainInput = Codegen.stringProp("plainInput").arg($.plainInput).def("fixed").getNullable();
             return $;
         }
     }

--- a/pkg/codegen/testing/test/testdata/plain-and-default/java/src/main/java/com/pulumi/foobar/ModuleResource.java
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/java/src/main/java/com/pulumi/foobar/ModuleResource.java
@@ -51,6 +51,7 @@ public class ModuleResource extends com.pulumi.resources.CustomResource {
         super("foobar::ModuleResource", name, null, makeResourceOptions(options, id), false);
     }
 
+    @SuppressWarnings("deprecation")
     private static ModuleResourceArgs makeArgs(ModuleResourceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;

--- a/pkg/codegen/testing/test/testdata/plain-and-default/java/src/main/java/com/pulumi/foobar/ModuleResource.java
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/java/src/main/java/com/pulumi/foobar/ModuleResource.java
@@ -51,17 +51,12 @@ public class ModuleResource extends com.pulumi.resources.CustomResource {
         super("foobar::ModuleResource", name, null, makeResourceOptions(options, id), false);
     }
 
-    @SuppressWarnings("deprecation")
     private static ModuleResourceArgs makeArgs(ModuleResourceArgs args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         if (options != null && options.getUrn().isPresent()) {
             return null;
         }
         var builder = args == null ? ModuleResourceArgs.builder() : ModuleResourceArgs.builder(args);
-        return builder
-            .optionalConst("val")
-            .plainOptionalConst("val")
-            .plainRequiredConst("val")
-            .build();
+        return builder.build();
     }
 
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {

--- a/pkg/codegen/testing/test/testdata/plain-and-default/java/src/main/java/com/pulumi/foobar/ModuleResourceArgs.java
+++ b/pkg/codegen/testing/test/testdata/plain-and-default/java/src/main/java/com/pulumi/foobar/ModuleResourceArgs.java
@@ -188,11 +188,27 @@ public final class ModuleResourceArgs extends com.pulumi.resources.ResourceArgs 
             return optionalBool(Output.of(optionalBool));
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder optionalConst(@Nullable Output<String> optionalConst) {
             $.optionalConst = optionalConst;
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder optionalConst(String optionalConst) {
             return optionalConst(Output.of(optionalConst));
         }
@@ -229,6 +245,14 @@ public final class ModuleResourceArgs extends com.pulumi.resources.ResourceArgs 
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder plainOptionalConst(@Nullable String plainOptionalConst) {
             $.plainOptionalConst = plainOptionalConst;
             return this;
@@ -249,6 +273,14 @@ public final class ModuleResourceArgs extends com.pulumi.resources.ResourceArgs 
             return this;
         }
 
+        /**
+         * @return builder
+         * 
+         * @deprecated
+         * This property has a constant value, which is set automatically.
+         * 
+         */
+        @Deprecated /* This property has a constant value, which is set automatically. */
         public Builder plainRequiredConst(String plainRequiredConst) {
             $.plainRequiredConst = plainRequiredConst;
             return this;
@@ -302,16 +334,16 @@ public final class ModuleResourceArgs extends com.pulumi.resources.ResourceArgs 
 
         public ModuleResourceArgs build() {
             $.optionalBool = Codegen.booleanProp("optionalBool").output().arg($.optionalBool).def(true).getNullable();
-            $.optionalConst = Codegen.stringProp("optionalConst").output().arg($.optionalConst).def("another").getNullable();
+            $.optionalConst = Codegen.stringProp("optionalConst").output().arg($.optionalConst).def("val").getNullable();
             $.optionalEnum = Codegen.objectProp("optionalEnum", EnumThing.class).output().arg($.optionalEnum).def(EnumThing.Eight).getNullable();
             $.optionalNumber = Codegen.doubleProp("optionalNumber").output().arg($.optionalNumber).def(4.2e+01).getNullable();
             $.optionalString = Codegen.stringProp("optionalString").output().arg($.optionalString).def("buzzer").getNullable();
             $.plainOptionalBool = Codegen.booleanProp("plainOptionalBool").arg($.plainOptionalBool).def(true).getNullable();
-            $.plainOptionalConst = Codegen.stringProp("plainOptionalConst").arg($.plainOptionalConst).def("another").getNullable();
+            $.plainOptionalConst = Codegen.stringProp("plainOptionalConst").arg($.plainOptionalConst).def("val").getNullable();
             $.plainOptionalNumber = Codegen.doubleProp("plainOptionalNumber").arg($.plainOptionalNumber).def(4.2e+01).getNullable();
             $.plainOptionalString = Codegen.stringProp("plainOptionalString").arg($.plainOptionalString).def("buzzer").getNullable();
             $.plainRequiredBool = Codegen.booleanProp("plainRequiredBool").arg($.plainRequiredBool).def(true).require();
-            $.plainRequiredConst = Codegen.stringProp("plainRequiredConst").arg($.plainRequiredConst).def("another").require();
+            $.plainRequiredConst = Codegen.stringProp("plainRequiredConst").arg($.plainRequiredConst).def("val").require();
             $.plainRequiredNumber = Codegen.doubleProp("plainRequiredNumber").arg($.plainRequiredNumber).def(4.2e+01).require();
             $.plainRequiredString = Codegen.stringProp("plainRequiredString").arg($.plainRequiredString).def("buzzer").require();
             $.requiredBool = Codegen.booleanProp("requiredBool").output().arg($.requiredBool).def(true).require();


### PR DESCRIPTION
## Summary

Split out of #2267, which needs this to set discriminator tags automatically.

This PR makes 3 changes:

1. Literal properties have that property correctly set.
2. Literal builder args are now deprecated, since they were previously not consistently applied. 
3. Programgen now omits generating literal properties, since that isn't necessary (1) and would warn (2).