### PR TITLE
Select union members by wire shape in the runtime

### DIFF
--- a/sdk/java/pulumi/src/main/java/com/pulumi/core/TypeShape.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/core/TypeShape.java
@@ -10,6 +10,7 @@ import com.pulumi.core.internal.annotations.InternalUse;
 import javax.annotation.CheckReturnValue;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
@@ -163,6 +164,11 @@ public final class TypeShape<T> {
         var parameterClass = parameter.getType();
         var token = TypeToken.of(parameter.getParameterizedType());
         return extract(parameterClass, token);
+    }
+
+    @InternalUse
+    public static TypeShape<?> extract(Field field) {
+        return extract(field.getType(), TypeToken.of(field.getGenericType()));
     }
 
     @InternalUse

--- a/sdk/java/pulumi/src/main/java/com/pulumi/core/annotations/ConstValue.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/core/annotations/ConstValue.java
@@ -1,0 +1,22 @@
+package com.pulumi.core.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used by a Pulumi Cloud Provider Package to mark a property whose schema pins it to
+ * one constant value.
+ * <p>
+ * Place it on a {@link CustomType.Setter} method or on an {@link Import} field.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface ConstValue {
+    /**
+     * @return the constant, rendered as a string. The runtime parses it according to the type of
+     * the annotated property.
+     */
+    String value();
+}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/core/annotations/UnionType.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/core/annotations/UnionType.java
@@ -1,0 +1,56 @@
+package com.pulumi.core.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used by a Pulumi Cloud Provider Package to mark an interface that stands for a
+ * schema union.
+ * <p>
+ * The interface carries one {@link UnionType.Case} annotation per union member. When the Pulumi
+ * runtime deserializes a value into the interface, it selects the one member whose wire shape
+ * admits the value.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface UnionType {
+
+    /**
+     * Annotation used by a Pulumi Cloud Provider Package to declare one member of a union
+     * interface marked with {@link UnionType}.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @Repeatable(Case.List.class)
+    @interface Case {
+        /**
+         * @return the class the runtime produces for this member. Either a class that implements
+         * the annotated interface, or a case class that wraps a value of the wire type.
+         */
+        Class<?> type();
+
+        /**
+         * @return the class references of the wire type, in the same encoding as
+         * {@link Export#refs()}. Empty when the wire type is {@link #type()} itself.
+         */
+        Class<?>[] refs() default {};
+
+        /**
+         * @return the generic tree shape of the wire type, in the same encoding as
+         * {@link Export#tree()}
+         */
+        String tree() default "";
+
+        /**
+         * Container for repeated {@link Case} annotations.
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.TYPE)
+        @interface List {
+            Case[] value();
+        }
+    }
+}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/core/internal/UnionCase.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/core/internal/UnionCase.java
@@ -1,0 +1,17 @@
+package com.pulumi.core.internal;
+
+import com.pulumi.core.internal.annotations.InternalUse;
+
+/**
+ * A case class of a {@link com.pulumi.core.annotations.UnionType} interface: a member of the
+ * union that is not itself a class implementing the interface, held by value.
+ * <p>
+ * The Pulumi runtime serializes a case class as its {@link #value()}.
+ */
+@InternalUse
+public interface UnionCase {
+    /**
+     * @return the wrapped member value
+     */
+    Object value();
+}

--- a/sdk/java/pulumi/src/main/java/com/pulumi/provider/internal/properties/PropertyValueSerializer.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/provider/internal/properties/PropertyValueSerializer.java
@@ -22,8 +22,10 @@ import com.pulumi.core.annotations.Import;
 import com.pulumi.core.internal.Internal;
 import com.pulumi.core.internal.OutputData;
 import com.pulumi.core.internal.OutputInternal;
+import com.pulumi.core.internal.UnionCase;
 import com.pulumi.resources.DependencyResource;
 import com.pulumi.resources.Resource;
+import com.pulumi.serialization.internal.UnionTypes;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -84,6 +86,10 @@ public final class PropertyValueSerializer {
             return null;
         }
 
+        if (UnionTypes.of(rawType).isPresent()) {
+            return deserializeUnion(value, rawType, path);
+        }
+
         switch (value.getType()) {
             case STRING:
                 if (rawType == String.class) {
@@ -141,6 +147,54 @@ public final class PropertyValueSerializer {
         throw new IllegalArgumentException(
             String.format("Unsupported type for deserialization: %s to %s, path: %s", 
                 value.getType().name(), rawType.getName(), path));
+    }
+
+    private static Object deserializeUnion(PropertyValue value, Class<?> unionType, String[] path) {
+        var member = UnionTypes.select(unionType, wireValue(value)).orThrow(
+            message -> new PropertyDeserializationException(message, path, unionType, value, null));
+        var converted = deserializeValue(value, member.wire().toGSON().getType(), path);
+        return UnionTypes.wrap(member, converted);
+    }
+
+    // The plain form of a value that UnionTypes matches against members: secrets and outputs are
+    // unwrapped, and a computed value becomes the unknown sentinel.
+    private static Object wireValue(PropertyValue value) {
+        switch (value.getType()) {
+            case NULL:
+                return null;
+            case BOOL:
+                return value.getBooleanValue();
+            case NUMBER:
+                return value.getNumberValue();
+            case STRING:
+                return value.getStringValue();
+            case ARRAY: {
+                var list = new ArrayList<>();
+                for (var element : value.getArrayValue()) {
+                    list.add(wireValue(element));
+                }
+                return list;
+            }
+            case OBJECT: {
+                var map = new HashMap<String, Object>();
+                value.getObjectValue().forEach((k, v) -> map.put(k, wireValue(v)));
+                return map;
+            }
+            case ASSET:
+                return value.getAssetValue();
+            case ARCHIVE:
+                return value.getArchiveValue();
+            case SECRET:
+                return wireValue(value.getSecretValue());
+            case OUTPUT: {
+                var inner = value.getOutputValue().getValue();
+                return inner == null ? UnionTypes.UNKNOWN : wireValue(inner);
+            }
+            case RESOURCE:
+                return value.getResourceValue();
+            default:
+                return UnionTypes.UNKNOWN;
+        }
     }
 
     private static Object deserializeOutput(PropertyValue value, java.lang.reflect.Type targetType, String[] path) {
@@ -517,6 +571,10 @@ public final class PropertyValueSerializer {
 
         if (value instanceof PropertyValue) {
             return (PropertyValue) value;
+        }
+
+        if (value instanceof UnionCase) {
+            return serializeValue(((UnionCase) value).value(), path);
         }
 
         // Handle collections

--- a/sdk/java/pulumi/src/main/java/com/pulumi/serialization/internal/Converter.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/serialization/internal/Converter.java
@@ -283,6 +283,10 @@ public class Converter {
             return tryConvertMap(context, value, targetType);
         }
 
+        if (UnionTypes.of(targetType.getType()).isPresent()) {
+            return tryConvertUnion(context, value, targetType);
+        }
+
         var hasAnnotatedBuilder = targetType.hasAnnotatedClass(CustomType.Builder.class);
         if (hasAnnotatedBuilder) {
             var builderType = targetType.getAnnotatedClass(CustomType.Builder.class);
@@ -508,6 +512,14 @@ public class Converter {
         }
     }
 
+    private Object tryConvertUnion(String context, Object value, TypeShape<?> targetType) {
+        var member = UnionTypes.select(targetType.getType(), value).orThrow(
+                message -> new IllegalArgumentException(String.format("%s; %s", context, message)));
+        var converted = tryConvertObjectInner(
+                String.format("%s(%s)", context, member.type().getSimpleName()), value, member.wire());
+        return UnionTypes.wrap(member, converted);
+    }
+
     @Nullable
     private Either<Object, Object> tryConvertOneOf(String context, Object value, TypeShape<?> targetType) {
         var leftType = targetType.getParameter(0)
@@ -714,6 +726,13 @@ public class Converter {
             return;
         }
 
+        if (UnionTypes.of(targetType.getType()).isPresent()) {
+            for (var member : UnionTypes.membersOf(targetType.getType())) {
+                checkTargetType(context, member.wire(), seenTypes);
+            }
+            return;
+        }
+
         var propertyTypeAnnotation = targetType.getAnnotation(CustomType.class);
         if (propertyTypeAnnotation.isPresent()) {
             var hasAnnotatedBuilder = targetType.hasAnnotatedClass(CustomType.Builder.class);
@@ -747,14 +766,14 @@ public class Converter {
         return processSetters(builder, m -> extractSetterParameter(m));
     }
 
-    private static <T> Map<String, T> processSetters(Class<?> builder, Function<Method, T> processor) {
+    static <T> Map<String, T> processSetters(Class<?> builder, Function<Method, T> processor) {
         return Arrays.stream(builder.getDeclaredMethods())
                 .filter(s -> s.isAnnotationPresent(CustomType.Setter.class))
                 .peek(s -> s.setAccessible(true))
                 .collect(toMap(s -> extractSetterName(s), processor));
     }
 
-    private static Parameter extractSetterParameter(Method method) {
+    static Parameter extractSetterParameter(Method method) {
         return Arrays.stream(method.getParameters()).collect(toSingleton(
                 cause -> new IllegalArgumentException(String.format(
                         "Expected setter named '%s' annotated with @%s to have exactly one parameter",
@@ -763,7 +782,7 @@ public class Converter {
         ));
     }
 
-    private static String extractSetterName(Method method) {
+    static String extractSetterName(Method method) {
         // we cannot just use parameter.getName(),
         // because it will be different at runtime e.g. 'arg0', 'arg1', etc.
         // also codegen must escape the names in edge cases, e.g. 'default_'

--- a/sdk/java/pulumi/src/main/java/com/pulumi/serialization/internal/Serializer.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/serialization/internal/Serializer.java
@@ -19,6 +19,7 @@ import com.pulumi.core.internal.CompletableFutures;
 import com.pulumi.core.internal.Constants;
 import com.pulumi.core.internal.Internal;
 import com.pulumi.core.internal.OutputData;
+import com.pulumi.core.internal.UnionCase;
 import com.pulumi.core.internal.annotations.InternalUse;
 import com.pulumi.resources.ComponentResource;
 import com.pulumi.resources.CustomResource;
@@ -132,6 +133,11 @@ public class Serializer {
             log.excessive(String.format("Serialize property[%s]: Recursion into Optional", ctx));
 
             return serializeAsync(ctx, optional.orElse(null), keepResources);
+        }
+
+        if (prop instanceof UnionCase) {
+            log.excessive(String.format("Serialize property[%s]: Recursion into UnionCase", ctx));
+            return serializeAsync(ctx, ((UnionCase) prop).value(), keepResources);
         }
 
         if (prop instanceof InputArgs) {

--- a/sdk/java/pulumi/src/main/java/com/pulumi/serialization/internal/UnionTypes.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/serialization/internal/UnionTypes.java
@@ -1,0 +1,373 @@
+package com.pulumi.serialization.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonElement;
+import com.pulumi.asset.Archive;
+import com.pulumi.asset.Asset;
+import com.pulumi.asset.AssetOrArchive;
+import com.pulumi.core.Either;
+import com.pulumi.core.Output;
+import com.pulumi.core.TypeShape;
+import com.pulumi.core.annotations.ConstValue;
+import com.pulumi.core.annotations.CustomType;
+import com.pulumi.core.annotations.EnumType;
+import com.pulumi.core.annotations.Import;
+import com.pulumi.core.annotations.UnionType;
+import com.pulumi.core.internal.Optionals;
+import com.pulumi.core.internal.Reflection;
+import com.pulumi.core.internal.annotations.InternalUse;
+import com.pulumi.resources.Resource;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeSet;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Reads the {@link UnionType} annotations of a generated union interface and selects the member
+ * that a wire value belongs to.
+ */
+@InternalUse
+public final class UnionTypes {
+
+    /**
+     * A wire value the runtime cannot examine. It matches every member.
+     */
+    public static final Object UNKNOWN = new Object();
+
+    private UnionTypes() {
+        throw new UnsupportedOperationException("static class");
+    }
+
+    /**
+     * One member of a union interface.
+     */
+    public static final class Member {
+        private final Class<?> type;
+        private final TypeShape<?> wire;
+
+        private Member(Class<?> type, TypeShape<?> wire) {
+            this.type = type;
+            this.wire = wire;
+        }
+
+        /**
+         * @return the class the runtime produces for this member
+         */
+        public Class<?> type() {
+            return this.type;
+        }
+
+        /**
+         * @return the type the wire value is converted to before it is wrapped
+         */
+        public TypeShape<?> wire() {
+            return this.wire;
+        }
+
+        /**
+         * @return true when {@link #type()} is a case class that wraps a value of {@link #wire()}
+         */
+        public boolean isCase() {
+            return !this.type.equals(this.wire.getType());
+        }
+
+        @Override
+        public String toString() {
+            return this.isCase()
+                    ? String.format("%s(%s)", this.type.getSimpleName(), this.wire.asString())
+                    : this.type.getTypeName();
+        }
+    }
+
+    /**
+     * @return the union annotation of {@code type}, if it is a generated union interface
+     */
+    public static Optional<UnionType> of(Class<?> type) {
+        return Optional.ofNullable(type.getAnnotation(UnionType.class));
+    }
+
+    /**
+     * @return the members of the union {@code type}, in declaration order
+     */
+    public static ImmutableList<Member> membersOf(Class<?> type) {
+        var members = ImmutableList.<Member>builder();
+        for (var unionCase : type.getAnnotationsByType(UnionType.Case.class)) {
+            var wire = unionCase.refs().length == 0
+                    ? TypeShape.of(unionCase.type())
+                    : TypeShape.fromTree(unionCase.refs(), unionCase.tree());
+            members.add(new Member(unionCase.type(), wire));
+        }
+        return members.build();
+    }
+
+    /**
+     * Selects the member of the union {@code type} that {@code value} belongs to.
+     *
+     * @param value a wire value: null, a String, a Number, a Boolean, a List, a Map, an
+     *              {@link AssetOrArchive}, a {@link Resource}, or {@link #UNKNOWN}
+     * @return the member, or a message explaining why no single member fits
+     */
+    public static Either<String, Member> select(Class<?> type, @Nullable Object value) {
+        var members = membersOf(type);
+        if (members.isEmpty()) {
+            return Either.ofLeft(String.format(
+                    "Expected '%s' annotated with @%s to also carry at least one @%s.Case, found none",
+                    type.getTypeName(), UnionType.class.getSimpleName(), UnionType.class.getSimpleName()
+            ));
+        }
+
+        var candidates = members.stream()
+                .filter(member -> matches(value, member.wire()))
+                .collect(toList());
+        if (candidates.size() == 1) {
+            return Either.ofRight(candidates.get(0));
+        }
+
+        var pool = candidates.isEmpty() ? members : candidates;
+        return Either.ofLeft(String.format(
+                "Expected a value that fits one member of '%s', got %s that fits %s: %s",
+                type.getTypeName(), describe(value), candidates.isEmpty() ? "none of" : "several of",
+                pool.stream().map(Member::toString).collect(joining(", "))
+        ));
+    }
+
+    /**
+     * Wraps a value converted to {@code member.wire()} in the member's case class, or returns it
+     * unchanged when the member implements the union interface itself.
+     */
+    public static Object wrap(Member member, Object converted) {
+        if (!member.isCase()) {
+            return converted;
+        }
+        var constructors = member.type().getDeclaredConstructors();
+        if (constructors.length != 1 || constructors[0].getParameterCount() != 1) {
+            throw new IllegalArgumentException(String.format(
+                    "Expected union case '%s' to declare exactly one constructor with one parameter, got: %s",
+                    member.type().getTypeName(), Arrays.toString(constructors)
+            ));
+        }
+        var constructor = constructors[0];
+        try {
+            constructor.setAccessible(true);
+            return constructor.newInstance(converted);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException(String.format(
+                    "Failed to construct union case '%s': %s", member.type().getTypeName(), e.getMessage()
+            ), e);
+        } finally {
+            constructor.setAccessible(false);
+        }
+    }
+
+    /**
+     * Reports whether {@code value} can belong to {@code type} on the wire.
+     */
+    static boolean matches(@Nullable Object value, TypeShape<?> type) {
+        if (value == UNKNOWN) {
+            return true;
+        }
+        var clazz = type.getType();
+
+        if (Optional.class.isAssignableFrom(clazz)) {
+            return value == null || matches(value, parameter(type, 0));
+        }
+        if (Output.class.isAssignableFrom(clazz)) {
+            return matches(value, parameter(type, 0));
+        }
+        if (value == null) {
+            return false;
+        }
+
+        if (Object.class.equals(clazz) || JsonElement.class.isAssignableFrom(clazz)) {
+            return true;
+        }
+        if (String.class.equals(clazz)) {
+            return value instanceof String;
+        }
+        if (boolean.class.equals(clazz) || Boolean.class.equals(clazz)) {
+            return value instanceof Boolean;
+        }
+        if (isNumber(clazz)) {
+            return value instanceof Number;
+        }
+        if (clazz.isEnum()) {
+            return enumAdmits(type, value);
+        }
+        if (Either.class.isAssignableFrom(clazz)) {
+            return matches(value, parameter(type, 0)) || matches(value, parameter(type, 1));
+        }
+        if (List.class.isAssignableFrom(clazz)) {
+            var element = parameter(type, 0);
+            return value instanceof List
+                    && ((List<?>) value).stream().allMatch(v -> matches(v, element));
+        }
+        if (Map.class.isAssignableFrom(clazz)) {
+            var element = parameter(type, 1);
+            return value instanceof Map
+                    && ((Map<?, ?>) value).values().stream().allMatch(v -> matches(v, element));
+        }
+        if (Archive.class.isAssignableFrom(clazz)) {
+            return value instanceof Archive;
+        }
+        if (AssetOrArchive.class.isAssignableFrom(clazz)) {
+            return value instanceof Asset;
+        }
+        if (Resource.class.isAssignableFrom(clazz)) {
+            return clazz.isInstance(value);
+        }
+        if (of(clazz).isPresent()) {
+            return membersOf(clazz).stream().anyMatch(member -> matches(value, member.wire()));
+        }
+
+        var properties = propertiesOf(clazz);
+        if (properties.isPresent()) {
+            return value instanceof Map && objectMatches((Map<?, ?>) value, properties.get());
+        }
+        return clazz.isInstance(value);
+    }
+
+    private static boolean objectMatches(Map<?, ?> value, List<Property> properties) {
+        var declared = properties.stream().map(p -> p.name).collect(toList());
+        if (!declared.containsAll(value.keySet())) {
+            return false;
+        }
+        for (var property : properties) {
+            var v = value.get(property.name);
+            if (v == null) {
+                if (property.required) {
+                    return false;
+                }
+                continue;
+            }
+            if (property.constant != null && !constantAdmits(property, v)) {
+                return false;
+            }
+            if (!matches(v, property.type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean constantAdmits(Property property, Object value) {
+        if (value == UNKNOWN) {
+            return true;
+        }
+        var clazz = unwrap(property.type).getType();
+        if (isNumber(clazz)) {
+            return value instanceof Number
+                    && ((Number) value).doubleValue() == Double.parseDouble(property.constant);
+        }
+        if (boolean.class.equals(clazz) || Boolean.class.equals(clazz)) {
+            return Boolean.valueOf(property.constant).equals(value);
+        }
+        return property.constant.equals(value);
+    }
+
+    private static boolean enumAdmits(TypeShape<?> type, Object value) {
+        var converter = type.getAnnotatedMethod(EnumType.Converter.class);
+        for (var constant : type.getType().getEnumConstants()) {
+            try {
+                var literal = converter.invoke(constant);
+                if (literal instanceof Number && value instanceof Number) {
+                    if (((Number) literal).doubleValue() == ((Number) value).doubleValue()) {
+                        return true;
+                    }
+                } else if (Objects.equals(literal, value)) {
+                    return true;
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new IllegalStateException(String.format("Unexpected exception: %s", e.getMessage()), e);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A property of an object member: a builder setter of a {@link CustomType}, or an
+     * {@link Import} field of an args class.
+     */
+    private static final class Property {
+        private final String name;
+        private final boolean required;
+        private final TypeShape<?> type;
+        @Nullable
+        private final String constant;
+
+        private Property(String name, boolean required, TypeShape<?> type, @Nullable ConstValue constant) {
+            this.name = name;
+            this.required = required;
+            this.type = type;
+            this.constant = constant == null ? null : constant.value();
+        }
+    }
+
+    private static Optional<List<Property>> propertiesOf(Class<?> clazz) {
+        var shape = TypeShape.of(clazz);
+        if (shape.hasAnnotatedClass(CustomType.Builder.class)) {
+            var builder = shape.getAnnotatedClass(CustomType.Builder.class);
+            var properties = Converter.processSetters(builder, method -> {
+                var parameter = Converter.extractSetterParameter(method);
+                return new Property(
+                        Converter.extractSetterName(method),
+                        !parameter.isAnnotationPresent(Nullable.class),
+                        TypeShape.extract(parameter),
+                        method.getAnnotation(ConstValue.class)
+                );
+            });
+            return Optional.of(ImmutableList.copyOf(properties.values()));
+        }
+
+        var fields = Reflection.allFields(clazz).stream()
+                .filter(field -> field.isAnnotationPresent(Import.class))
+                .collect(toList());
+        if (fields.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(fields.stream().map(field -> {
+            var annotation = field.getAnnotation(Import.class);
+            return new Property(
+                    Optionals.ofBlank(annotation.name()).orElse(field.getName()),
+                    annotation.required(), TypeShape.extract(field), field.getAnnotation(ConstValue.class)
+            );
+        }).collect(toList()));
+    }
+
+    private static TypeShape<?> unwrap(TypeShape<?> type) {
+        var clazz = type.getType();
+        if (Optional.class.isAssignableFrom(clazz) || Output.class.isAssignableFrom(clazz)) {
+            return unwrap(parameter(type, 0));
+        }
+        return type;
+    }
+
+    private static TypeShape<?> parameter(TypeShape<?> type, int index) {
+        return type.getParameter(index).orElseGet(() -> TypeShape.of(Object.class));
+    }
+
+    private static boolean isNumber(Class<?> clazz) {
+        return int.class.equals(clazz) || Integer.class.equals(clazz)
+                || double.class.equals(clazz) || Double.class.equals(clazz);
+    }
+
+    private static String describe(@Nullable Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value == UNKNOWN) {
+            return "an unknown value";
+        }
+        if (value instanceof Map) {
+            return "an object with keys " + new TreeSet<>(((Map<?, ?>) value).keySet());
+        }
+        return "a " + value.getClass().getSimpleName();
+    }
+}

--- a/sdk/java/pulumi/src/test/java/com/pulumi/provider/internal/PropertyValueUnionTest.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/provider/internal/PropertyValueUnionTest.java
@@ -1,0 +1,158 @@
+package com.pulumi.provider.internal;
+
+import com.pulumi.core.Output;
+import com.pulumi.core.annotations.ConstValue;
+import com.pulumi.core.annotations.Import;
+import com.pulumi.core.annotations.UnionType;
+import com.pulumi.core.internal.Internal;
+import com.pulumi.core.internal.UnionCase;
+import com.pulumi.provider.internal.properties.PropertyDeserializationException;
+import com.pulumi.provider.internal.properties.PropertyValue;
+import com.pulumi.provider.internal.properties.PropertyValueSerializer;
+import com.pulumi.resources.ResourceArgs;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PropertyValueUnionTest {
+
+    @UnionType
+    @UnionType.Case(type = VariantOneArgs.class)
+    @UnionType.Case(type = VariantTwoArgs.class)
+    @UnionType.Case(type = ShapeArgs.OfString.class, refs = {String.class}, tree = "[0]")
+    public interface ShapeArgs {
+        static ShapeArgs of(String value) {
+            return new OfString(value);
+        }
+
+        final class OfString implements ShapeArgs, UnionCase {
+            private final String value;
+
+            private OfString(String value) {
+                this.value = Objects.requireNonNull(value);
+            }
+
+            @Override
+            public String value() {
+                return value;
+            }
+        }
+    }
+
+    static class VariantOneArgs extends ResourceArgs implements ShapeArgs {
+        @Import(name = "kind", required = true)
+        @ConstValue("one")
+        private Output<String> kind;
+
+        @Import(name = "field1")
+        private Output<String> field1;
+
+        private VariantOneArgs() {
+        }
+    }
+
+    static class VariantTwoArgs extends ResourceArgs implements ShapeArgs {
+        @Import(name = "kind", required = true)
+        @ConstValue("two")
+        private Output<String> kind;
+
+        @Import(name = "field1")
+        private Output<String> field1;
+
+        private VariantTwoArgs() {
+        }
+    }
+
+    static class HolderArgs extends ResourceArgs {
+        @Import(name = "shape", required = true)
+        private ShapeArgs shape;
+
+        @Import(name = "shapes")
+        private List<ShapeArgs> shapes;
+
+        @Import(name = "optionalShape")
+        private ShapeArgs optionalShape;
+
+        private HolderArgs() {
+        }
+    }
+
+    @Test
+    void deserializesTheMemberAConstantSelects() {
+        var value = PropertyValue.of(Map.of(
+                "shape", PropertyValue.of(Map.of(
+                        "kind", PropertyValue.of("two"),
+                        "field1", PropertyValue.of("x")
+                ))
+        ));
+        var args = PropertyValueSerializer.deserialize(value, HolderArgs.class);
+        assertThat(args.shape).isInstanceOf(VariantTwoArgs.class);
+        assertThat(Internal.of(((VariantTwoArgs) args.shape).field1).getValueNullable().join()).isEqualTo("x");
+    }
+
+    @Test
+    void deserializesACaseAndItsNestedForm() {
+        var value = PropertyValue.of(Map.of(
+                "shape", PropertyValue.of("hello"),
+                "shapes", PropertyValue.of(List.of(
+                        PropertyValue.of("a"),
+                        PropertyValue.of(Map.of("kind", PropertyValue.of("one")))
+                ))
+        ));
+        var args = PropertyValueSerializer.deserialize(value, HolderArgs.class);
+        assertThat(args.shape).isInstanceOf(ShapeArgs.OfString.class);
+        assertThat(((ShapeArgs.OfString) args.shape).value()).isEqualTo("hello");
+        assertThat(args.shapes.get(0)).isInstanceOf(ShapeArgs.OfString.class);
+        assertThat(args.shapes.get(1)).isInstanceOf(VariantOneArgs.class);
+    }
+
+    @Test
+    void rejectsAValueThatFitsNoMember() {
+        var value = PropertyValue.of(Map.of("shape", PropertyValue.of(true)));
+        assertThatThrownBy(() -> PropertyValueSerializer.deserialize(value, HolderArgs.class))
+                .isInstanceOf(PropertyDeserializationException.class)
+                .hasMessageContaining("Expected a value that fits one member of")
+                .hasMessageContaining("got a Boolean that fits none of");
+    }
+
+    @Test
+    void deserializesANullUnionAsNull() {
+        var value = PropertyValue.of(Map.of(
+                "shape", PropertyValue.of("hello"),
+                "optionalShape", PropertyValue.NULL
+        ));
+        var args = PropertyValueSerializer.deserialize(value, HolderArgs.class);
+        assertThat(args.optionalShape).isNull();
+    }
+
+    @Test
+    void rejectsAnUnknownOutputThatFitsSeveralMembers() {
+        var value = PropertyValue.of(Map.of("shape", PropertyValue.of(Map.of(
+                "kind", PropertyValue.of(new PropertyValue.OutputReference(PropertyValue.COMPUTED, Set.of()))
+        ))));
+        assertThatThrownBy(() -> PropertyValueSerializer.deserialize(value, HolderArgs.class))
+                .isInstanceOf(PropertyDeserializationException.class)
+                .hasMessageContaining("fits several of");
+    }
+
+    @Test
+    void serializesACaseAsItsValue() {
+        var serialized = PropertyValueSerializer.stateFromComponentResource(new Holder(ShapeArgs.of("hello")));
+        assertThat(serialized).isEqualTo(Map.of("shape", PropertyValue.of("hello")));
+    }
+
+    static class Holder {
+        @com.pulumi.core.annotations.Export(name = "shape")
+        private final ShapeArgs shape;
+
+        Holder(ShapeArgs shape) {
+            this.shape = shape;
+        }
+    }
+}

--- a/sdk/java/pulumi/src/test/java/com/pulumi/serialization/internal/UnionTypesTest.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/serialization/internal/UnionTypesTest.java
@@ -1,0 +1,304 @@
+package com.pulumi.serialization.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Value;
+import com.pulumi.Log;
+import com.pulumi.core.TypeShape;
+import com.pulumi.core.annotations.ConstValue;
+import com.pulumi.core.annotations.CustomType;
+import com.pulumi.core.annotations.UnionType;
+import com.pulumi.core.internal.UnionCase;
+import com.pulumi.serialization.internal.ConverterTests.ContainerColor;
+import com.pulumi.test.internal.PulumiTestInternal;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.pulumi.serialization.internal.ConverterTests.serializeToValueAsync;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UnionTypesTest {
+
+    private final static Log log = PulumiTestInternal.mockLog();
+
+    // A union of two objects that differ only in a constant, a string, a list of strings, and an
+    // enum with numeric literals. Every fully-known wire value fits exactly one member.
+    @UnionType
+    @UnionType.Case(type = VariantOne.class)
+    @UnionType.Case(type = VariantTwo.class)
+    @UnionType.Case(type = Shape.OfString.class, refs = {String.class}, tree = "[0]")
+    @UnionType.Case(type = Shape.OfList.class, refs = {List.class, String.class}, tree = "[0,1]")
+    @UnionType.Case(type = Shape.OfSize.class, refs = {ConverterTests.ContainerSize.class}, tree = "[0]")
+    public interface Shape {
+        static Shape of(String value) {
+            return new OfString(value);
+        }
+
+        static Shape of(List<String> value) {
+            return new OfList(value);
+        }
+
+        static Shape of(ConverterTests.ContainerSize value) {
+            return new OfSize(value);
+        }
+
+        final class OfString implements Shape, UnionCase {
+            private final String value;
+
+            private OfString(String value) {
+                this.value = Objects.requireNonNull(value);
+            }
+
+            @Override
+            public String value() {
+                return value;
+            }
+        }
+
+        final class OfList implements Shape, UnionCase {
+            private final List<String> value;
+
+            private OfList(List<String> value) {
+                this.value = Objects.requireNonNull(value);
+            }
+
+            @Override
+            public List<String> value() {
+                return value;
+            }
+        }
+
+        final class OfSize implements Shape, UnionCase {
+            private final ConverterTests.ContainerSize value;
+
+            private OfSize(ConverterTests.ContainerSize value) {
+                this.value = Objects.requireNonNull(value);
+            }
+
+            @Override
+            public ConverterTests.ContainerSize value() {
+                return value;
+            }
+        }
+    }
+
+    @CustomType
+    public static final class VariantOne implements Shape {
+        private String kind;
+        private @Nullable String field1;
+
+        private VariantOne() {
+        }
+
+        @CustomType.Builder
+        public static final class Builder {
+            private final VariantOne $ = new VariantOne();
+
+            @CustomType.Setter
+            @ConstValue("one")
+            public Builder kind(String kind) {
+                $.kind = kind;
+                return this;
+            }
+
+            @CustomType.Setter
+            public Builder field1(@Nullable String field1) {
+                $.field1 = field1;
+                return this;
+            }
+
+            public VariantOne build() {
+                return $;
+            }
+        }
+    }
+
+    @CustomType
+    public static final class VariantTwo implements Shape {
+        private String kind;
+        private @Nullable String field1;
+
+        private VariantTwo() {
+        }
+
+        @CustomType.Builder
+        public static final class Builder {
+            private final VariantTwo $ = new VariantTwo();
+
+            @CustomType.Setter
+            @ConstValue("two")
+            public Builder kind(String kind) {
+                $.kind = kind;
+                return this;
+            }
+
+            @CustomType.Setter
+            public Builder field1(@Nullable String field1) {
+                $.field1 = field1;
+                return this;
+            }
+
+            public VariantTwo build() {
+                return $;
+            }
+        }
+    }
+
+    // Two objects with the same properties and no constant to tell them apart.
+    @UnionType
+    @UnionType.Case(type = Ambiguous.Left.class)
+    @UnionType.Case(type = Ambiguous.Right.class)
+    public interface Ambiguous {
+        @CustomType
+        final class Left implements Ambiguous {
+            private @Nullable String s;
+
+            @CustomType.Builder
+            public static final class Builder {
+                private final Left $ = new Left();
+
+                @CustomType.Setter
+                public Builder s(@Nullable String s) {
+                    $.s = s;
+                    return this;
+                }
+
+                public Left build() {
+                    return $;
+                }
+            }
+        }
+
+        @CustomType
+        final class Right implements Ambiguous {
+            private @Nullable String s;
+
+            @CustomType.Builder
+            public static final class Builder {
+                private final Right $ = new Right();
+
+                @CustomType.Setter
+                public Builder s(@Nullable String s) {
+                    $.s = s;
+                    return this;
+                }
+
+                public Right build() {
+                    return $;
+                }
+            }
+        }
+    }
+
+    private static Object convert(Object wire, Class<?> target) {
+        return convert(wire, TypeShape.of(target));
+    }
+
+    private static Object convert(Object wire, TypeShape<?> target) {
+        var converter = new Converter(log, new Deserializer(log));
+        Value serialized = serializeToValueAsync(wire).join();
+        return converter.convertValue("UnionTypesTest", serialized, target).getValueNullable();
+    }
+
+    @Test
+    void matchesByWireShape() {
+        assertThat(UnionTypes.matches("s", TypeShape.of(String.class))).isTrue();
+        assertThat(UnionTypes.matches(1.0, TypeShape.of(String.class))).isFalse();
+        assertThat(UnionTypes.matches(1.0, TypeShape.of(Integer.class))).isTrue();
+        assertThat(UnionTypes.matches(true, TypeShape.of(Double.class))).isFalse();
+        assertThat(UnionTypes.matches(true, TypeShape.of(Boolean.class))).isTrue();
+        assertThat(UnionTypes.matches(List.of("a"), TypeShape.list(String.class))).isTrue();
+        assertThat(UnionTypes.matches(List.of(1.0), TypeShape.list(String.class))).isFalse();
+        assertThat(UnionTypes.matches(Map.of("k", "v"), TypeShape.map(String.class, String.class))).isTrue();
+        assertThat(UnionTypes.matches(Map.of("k", 1.0), TypeShape.map(String.class, String.class))).isFalse();
+        assertThat(UnionTypes.matches("blue", TypeShape.of(ContainerColor.class))).isTrue();
+        assertThat(UnionTypes.matches("green", TypeShape.of(ContainerColor.class))).isFalse();
+        assertThat(UnionTypes.matches(6.0, TypeShape.of(ConverterTests.ContainerSize.class))).isTrue();
+        assertThat(UnionTypes.matches(7.0, TypeShape.of(ConverterTests.ContainerSize.class))).isFalse();
+        assertThat(UnionTypes.matches(null, TypeShape.of(String.class))).isFalse();
+        assertThat(UnionTypes.matches(null, TypeShape.optional(String.class))).isTrue();
+        assertThat(UnionTypes.matches(UnionTypes.UNKNOWN, TypeShape.of(String.class))).isTrue();
+    }
+
+    @Test
+    void matchesObjectsUnderTheClosedReading() {
+        var one = TypeShape.of(VariantOne.class);
+        assertThat(UnionTypes.matches(Map.of("kind", "one", "field1", "x"), one)).isTrue();
+        assertThat(UnionTypes.matches(Map.of("kind", "one"), one)).isTrue();
+        // Wrong constant.
+        assertThat(UnionTypes.matches(Map.of("kind", "two", "field1", "x"), one)).isFalse();
+        // Missing required property.
+        assertThat(UnionTypes.matches(Map.of("field1", "x"), one)).isFalse();
+        // Undeclared property.
+        assertThat(UnionTypes.matches(Map.of("kind", "one", "extra", "x"), one)).isFalse();
+        // Wrong property type.
+        assertThat(UnionTypes.matches(Map.of("kind", "one", "field1", 1.0), one)).isFalse();
+        assertThat(UnionTypes.matches("one", one)).isFalse();
+    }
+
+    @Test
+    void selectFindsTheOneMemberThatFits() {
+        assertThat(UnionTypes.select(Shape.class, Map.of("kind", "two")).right().type()).isEqualTo(VariantTwo.class);
+        assertThat(UnionTypes.select(Shape.class, "s").right().type()).isEqualTo(Shape.OfString.class);
+        assertThat(UnionTypes.select(Shape.class, List.of()).right().type()).isEqualTo(Shape.OfList.class);
+        assertThat(UnionTypes.select(Shape.class, 6.0).right().type()).isEqualTo(Shape.OfSize.class);
+
+        assertThat(UnionTypes.select(Shape.class, true).left()).isEqualTo(
+                "Expected a value that fits one member of '" + Shape.class.getTypeName() + "', got a Boolean " +
+                        "that fits none of: " + VariantOne.class.getTypeName() + ", " + VariantTwo.class.getTypeName() +
+                        ", OfString(java.lang.String), OfList(java.util.List<java.lang.String>), " +
+                        "OfSize(com.pulumi.serialization.internal.ConverterTests$ContainerSize)");
+        assertThat(UnionTypes.select(Ambiguous.class, Map.of("s", "x")).left()).isEqualTo(
+                "Expected a value that fits one member of '" + Ambiguous.class.getTypeName() + "', " +
+                        "got an object with keys [s] that fits several of: " +
+                        Ambiguous.Left.class.getTypeName() + ", " + Ambiguous.Right.class.getTypeName());
+    }
+
+    @Test
+    void converterProducesTheMemberOrItsCase() {
+        var two = convert(ImmutableMap.of("kind", "two", "field1", "x"), Shape.class);
+        assertThat(two).isInstanceOf(VariantTwo.class);
+        assertThat(((VariantTwo) two).kind).isEqualTo("two");
+        assertThat(((VariantTwo) two).field1).isEqualTo("x");
+
+        var string = convert("hello", Shape.class);
+        assertThat(string).isInstanceOf(Shape.OfString.class);
+        assertThat(((Shape.OfString) string).value()).isEqualTo("hello");
+
+        var list = convert(ImmutableList.of("a", "b"), Shape.class);
+        assertThat(list).isInstanceOf(Shape.OfList.class);
+        assertThat(((Shape.OfList) list).value()).isEqualTo(List.of("a", "b"));
+
+        var size = convert(6, Shape.class);
+        assertThat(size).isInstanceOf(Shape.OfSize.class);
+        assertThat(((Shape.OfSize) size).value()).isEqualTo(ConverterTests.ContainerSize.SixInch);
+
+        var nested = (List<?>) convert(ImmutableList.of("hello", ImmutableMap.of("kind", "one")),
+                TypeShape.list(Shape.class));
+        assertThat(nested.get(0)).isInstanceOf(Shape.OfString.class);
+        assertThat(nested.get(1)).isInstanceOf(VariantOne.class);
+    }
+
+    @Test
+    void converterRejectsAValueThatFitsNoMember() {
+        assertThatThrownBy(() -> convert(ImmutableMap.of("kind", "three"), Shape.class))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("UnionTypesTest; Expected a value that fits one member of")
+                .hasMessageContaining("got an object with keys [kind] that fits none of");
+    }
+
+    @Test
+    void serializerUnwrapsACase() {
+        assertThat(serializeToValueAsync(Shape.of("hello")).join())
+                .isEqualTo(serializeToValueAsync("hello").join());
+        assertThat(serializeToValueAsync(Shape.of(List.of("a"))).join())
+                .isEqualTo(serializeToValueAsync(List.of("a")).join());
+        assertThat(serializeToValueAsync(Shape.of(ConverterTests.ContainerSize.SixInch)).join())
+                .isEqualTo(serializeToValueAsync(6).join());
+    }
+}


### PR DESCRIPTION
This is the runtime half of strongly typed unions. It is the Java equivalent to https://github.com/pulumi/pulumi/pull/24484. This lets Java deserialize types into unions based on the shape of the type.

Instead of Python's reflection, we use Java's annotations:

- Add `@UnionType` and `@UnionType.Case` for interfaces that stand for a schema union, `@ConstValue` for properties a schema pins to a constant, and `UnionCase` for case classes that hold a non-object member by value.
- When the runtime deserializes a value into a `@UnionType` interface, it selects the one member whose wire shape admits the value. An object member admits a value under the closed reading: every key is a declared property, every required property is present, and a constant property holds its constant. The rules mirror `codegen.IsWireDiscriminatableUnionType` in pulumi/pulumi and `_wire_matches` in the Python SDK.
- A value that fits no member, or more than one, fails to deserialize with an error that names the members.
- Both the resource `Converter` and the provider `PropertyValueSerializer` apply the rule. Both serializers unwrap a case class to its value, so providers see no change on the wire.