### PR TITLE
[codegen] Combine list literals containing Outputs with Output.all()

### DIFF
--- a/.changes/unreleased/Improvements-2247.yaml
+++ b/.changes/unreleased/Improvements-2247.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: Improvements
+body: Bump the pulumi/pulumi version
+time: 2026-07-24T12:07:40.187618+01:00
+custom:
+    PR: "2247"

--- a/.changes/unreleased/bug-fixes-2308.yaml
+++ b/.changes/unreleased/bug-fixes-2308.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: bug-fixes
+body: Combine list literals containing Outputs with Output.all() so that generated programs compile
+time: 2026-09-04T17:44:18.617882+02:00
+custom:
+    PR: "2308"

--- a/pkg/codegen/java/gen_program_expressions.go
+++ b/pkg/codegen/java/gen_program_expressions.go
@@ -938,19 +938,39 @@ func (g *generator) GenTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 		}
 	}
 
+	// Builder setters for a list property accept List<T>, T... or Output<List<T>>, so a list with
+	// any Output element has no matching overload. Combine the elements with Output.all() instead,
+	// which yields the Output<List<T>> the setter expects.
+	outputList := false
+	if _, isArray := g.currentResourcePropertyType.(*schema.ArrayType); isArray {
+		for _, element := range expr.Expressions {
+			if isOutputExpression(element) {
+				outputList = true
+				break
+			}
+		}
+	}
+
 	closeList := func() {
-		if g.currentResourcePropertyType == nil {
+		if outputList || g.currentResourcePropertyType == nil {
 			g.Fgen(w, ")")
 		}
 	}
 
-	if g.currentResourcePropertyType == nil {
+	switch {
+	case outputList:
+		g.Fgen(w, "Output.all(")
+	case g.currentResourcePropertyType == nil:
 		// Arrays.asList() is used instead of List.of() because List.of() does not permit null elements.
 		// Elements may be null at runtime even if not literal nulls (e.g. variables).
 		g.Fgen(w, "Arrays.asList(")
 	}
 
 	genElement := func(w io.Writer, value model.Expression) {
+		if outputList {
+			g.genOutputTupleElement(w, value)
+			return
+		}
 		g.genNullableTupleElement(w, value)
 	}
 
@@ -985,6 +1005,31 @@ func (g *generator) GenTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 	})
 
 	closeList()
+}
+
+// isOutputExpression reports whether an expression itself generates an Output, as opposed to
+// merely containing one: an object literal holding an Output property still generates a builder
+// call, not an Output. Conversion intrinsics are unwrapped first, since they widen the type of
+// every element to a union with the property's own type.
+func isOutputExpression(expr model.Expression) bool {
+	for {
+		call, ok := expr.(*model.FunctionCallExpression)
+		if !ok || call.Name != pcl.IntrinsicConvert || len(call.Args) != 1 {
+			_, isOutput := expr.Type().(*model.OutputType)
+			return isOutput
+		}
+		expr = call.Args[0]
+	}
+}
+
+// genOutputTupleElement generates a tuple element for an Output.all() call, lifting plain values
+// into Outputs so that every argument matches the Output<T>... parameter.
+func (g *generator) genOutputTupleElement(w io.Writer, expr model.Expression) {
+	if isOutputExpression(expr) {
+		g.Fgenf(w, "%.v", expr)
+		return
+	}
+	g.Fgenf(w, "Output.of(%.v)", expr)
 }
 
 // genNullableTupleElement generates a tuple element, casting null literals to Object

--- a/pkg/codegen/testing/test/testdata/output-list-pp/java/output-list.java
+++ b/pkg/codegen/testing/test/testdata/output-list-pp/java/output-list.java
@@ -1,0 +1,63 @@
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.random.RandomPet;
+import com.pulumi.random.RandomShuffle;
+import com.pulumi.random.RandomShuffleArgs;
+import com.pulumi.infra.Bucket;
+import com.pulumi.infra.InfraFunctions;
+import com.pulumi.infra.inputs.GetPolicyDocumentArgs;
+import com.pulumi.infra.inputs.GetPolicyDocumentStatementArgs;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        var pet = new RandomPet("pet");
+
+        // A list whose elements are all plain values still generates plain varargs.
+        var plainList = new RandomShuffle("plainList", RandomShuffleArgs.builder()
+            .inputs(            
+                "a",
+                "b")
+            .build());
+
+        // A list mixing outputs and plain values has no matching builder overload as varargs,
+        // so it has to be combined with Output.all().
+        var mixedList = new RandomShuffle("mixedList", RandomShuffleArgs.builder()
+            .inputs(Output.all(            
+                pet.id(),
+                pet.id().applyValue(_id -> String.format("%s-suffix", _id)),
+                Output.of("literal")))
+            .build());
+
+        // A single-element list is generated the same way: the element is still an output.
+        var singleOutput = new RandomShuffle("singleOutput", RandomShuffleArgs.builder()
+            .inputs(Output.all(pet.id()))
+            .build());
+
+        // The same applies to a list nested inside invoke arguments, which is what makes the
+        // S3 bucket policy example in the registry docs fail to compile.
+        var sourceBucket = new Bucket("sourceBucket");
+
+        final var policyDocument = InfraFunctions.getPolicyDocument(GetPolicyDocumentArgs.builder()
+            .statements(GetPolicyDocumentStatementArgs.builder()
+                .actions("s3:GetObject")
+                .resources(Output.all(                
+                    sourceBucket.bucket(),
+                    sourceBucket.bucket().applyValue(_bucket -> String.format("%s/*", _bucket))))
+                .build())
+            .build());
+
+    }
+}

--- a/pkg/codegen/testing/test/testdata/output-list-pp/output-list.pp
+++ b/pkg/codegen/testing/test/testdata/output-list-pp/output-list.pp
@@ -1,0 +1,35 @@
+resource pet "random:index/randomPet:RandomPet" {}
+
+# A list whose elements are all plain values still generates plain varargs.
+resource plainList "random:index/randomShuffle:RandomShuffle" {
+    inputs = ["a", "b"]
+}
+
+# A list mixing outputs and plain values has no matching builder overload as varargs,
+# so it has to be combined with Output.all().
+resource mixedList "random:index/randomShuffle:RandomShuffle" {
+    inputs = [
+        pet.id,
+        "${pet.id}-suffix",
+        "literal"
+    ]
+}
+
+# A single-element list is generated the same way: the element is still an output.
+resource singleOutput "random:index/randomShuffle:RandomShuffle" {
+    inputs = [pet.id]
+}
+
+# The same applies to a list nested inside invoke arguments, which is what makes the
+# S3 bucket policy example in the registry docs fail to compile.
+resource sourceBucket "infra:index:Bucket" {}
+
+policyDocument = invoke("infra:index:getPolicyDocument", {
+    statements = [{
+        actions = ["s3:GetObject"]
+        resources = [
+            sourceBucket.bucket,
+            "${sourceBucket.bucket}/*"
+        ]
+    }]
+})


### PR DESCRIPTION
Fixes #1420.

### The problem

A list literal assigned to a list-typed property was generated as varargs, so a list holding any `Output` element produced code with no matching builder overload. This is what makes the [S3 bucket policy example](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketpolicy/) in the registry docs invalid:

```java
.resources(
    example.arn(),
    example.arn().applyValue(_arn -> String.format("%s/*", _arn)))
```

The setters take `List<T>`, `T...` or `Output<List<T>>`, none of which accepts a mix of `Output<T>` and `T`. Compiling the equivalent program against a real SDK gives:

```
error: method inputs in class Builder cannot be applied to given types;
  required: String[]
  found: Output<String>,Output<Object>,String
  reason: varargs mismatch; Output<String> cannot be converted to String
```

### The fix

When any element of the list is an `Output`, combine the elements with `Output.all()` and lift the plain ones with `Output.of()`, so every argument matches the `Output<T>...` parameter and the result is the `Output<List<T>>` the setter expects:

```java
.resources(Output.all(
    example.arn(),
    example.arn().applyValue(_arn -> String.format("%s/*", _arn))))
```

Two things worth knowing when reading the diff:

- Elements arrive wrapped in `__convert` intrinsics, which widen each element's type to a union with the property's own type. Those have to be unwrapped before checking whether the element is an `Output`.
- The check is whether an element *is* an `Output`, not whether it *contains* one. An object literal with an `Output` property still generates a builder call, so `ContainsOutputs` would wrongly wrap `.statements(...)` in `Output.all()` as well.

Lists with no `Output` elements are generated exactly as before.

### Also fixed

The first case in pulumi/pulumi-hcloud#1078 (`firewallIds(myfirewall.id())`, a single-element list holding an `Output`) has the same root cause and is fixed by the same change. The second case in that issue is unrelated.

The other complaint in #1420 — that `.applyValue(getPolicyDocumentResult -> getPolicyDocumentResult)` is redundant — no longer applies: the registry currently generates `.applyValue(_allowAccessFromAnotherAccount -> _allowAccessFromAnotherAccount.json())`, which does extract a field.

### Testing

- New program codegen test `pkg/codegen/testing/test/testdata/output-list-pp`, covering an all-plain list (unchanged output), a mixed list, a single-element list, and a list nested inside invoke arguments — the last mirrors the shape of the failing S3 example.
- The generated Java was compiled with `javac` against the published `com.pulumi:random` SDK to confirm the new form compiles and the old one does not.
- `make lint` is clean and `pkg/codegen/java` passes in full, including `TestGeneratePackage` (no SDK golden file changes).

Note: this branch also carries a pre-existing "Placeholder" commit adding `.changes/unreleased/Improvements-2247.yaml`, which was already on the branch and is unrelated to this change. Happy to drop it if it shouldn't be here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
