### PR TITLE
make sure to not livelock executor in Java 25 with paralellism 1

### DIFF
--- a/.changes/unreleased/bug-fixes-2314.yaml
+++ b/.changes/unreleased/bug-fixes-2314.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: bug-fixes
+body: Fix livelock in executor with JDK 25 and parallelism 1
+time: 2026-09-08T18:11:31.945030258+02:00
+custom:
+    PR: "2314"

--- a/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/DeploymentImpl.java
+++ b/sdk/java/pulumi/src/main/java/com/pulumi/deployment/internal/DeploymentImpl.java
@@ -85,6 +85,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -2037,6 +2039,19 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
         private final Map<CompletableFuture<Void>, List<String>> inFlightTasks = new ConcurrentHashMap<>();
         private final Queue<Exception> swallowedExceptions = new ConcurrentLinkedQueue<>();
 
+        /**
+         * The polling loop in {@link #loopUntilDone} must not re-submit itself to the
+         * default executor immediately: since Java 25 that executor is always the common
+         * {@link java.util.concurrent.ForkJoinPool} (JDK-8319447), and with a common-pool
+         * parallelism of 1 a tight resubmission loop keeps the sole worker busy forever,
+         * so the async continuations of the in-flight tasks never run and the program
+         * livelocks. Rescheduling each iteration with a small delay lets the worker go
+         * idle in between, and also stops the loop from burning a full CPU core.
+         * See https://github.com/pulumi/pulumi-java/issues/2270
+         */
+        private static final Executor pollingExecutor =
+                CompletableFuture.delayedExecutor(10, TimeUnit.MILLISECONDS);
+
         public DefaultRunner(Logger standardLogger, EngineLogger engineLogger) {
             this.standardLogger = Objects.requireNonNull(standardLogger);
             this.engineLogger = Objects.requireNonNull(engineLogger);
@@ -2148,8 +2163,8 @@ public class DeploymentImpl extends DeploymentInstanceHolder implements Deployme
                 if (checkForTasks(handleCompletion)) {
                     drainTasks.complete(null);
                 } else {
-                    // We need to reschedule the loop, to avoid hogging the async thread pool.
-                    ContextAwareCompletableFuture.runAsync(() -> loopUntilDone(drainTasks, handleCompletion));
+                    ContextAwareCompletableFuture.runAsync(
+                            () -> loopUntilDone(drainTasks, handleCompletion), pollingExecutor);
                 }
             } catch (Exception e) {
                 drainTasks.completeExceptionally(e);

--- a/sdk/java/pulumi/src/test/java/com/pulumi/deployment/internal/DefaultRunnerTest.java
+++ b/sdk/java/pulumi/src/test/java/com/pulumi/deployment/internal/DefaultRunnerTest.java
@@ -1,0 +1,89 @@
+package com.pulumi.deployment.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for https://github.com/pulumi/pulumi-java/issues/2270: the
+ * drain loop in {@link DeploymentImpl.DefaultRunner} must not re-submit itself
+ * to the common pool in a tight loop, otherwise a program livelocks on Java 25+
+ * when the common ForkJoinPool parallelism is 1.
+ */
+public class DefaultRunnerTest {
+
+    @Test
+    void testDrainLoopDoesNotBusySpin() throws Exception {
+        var log = InMemoryLogger.getLogger(Level.FINEST, "DefaultRunnerTest#testDrainLoopDoesNotBusySpin");
+        var runner = new DeploymentImpl.DefaultRunner(log, EngineLogger.ignore());
+
+        var result = runner.runAsync(() -> {
+            registerDelayedTask(runner, 250);
+            return 0;
+        }).get(60, TimeUnit.SECONDS);
+        assertThat(result.exitCode()).isZero();
+
+        // The loop logs "Remaining tasks" once per iteration. Polling every
+        // 10ms while the 250ms task runs yields a few dozen iterations; a
+        // tight resubmission loop yields tens of thousands.
+        var polls = log.getMessages().stream().filter(m -> m.contains("Remaining tasks")).count();
+        assertThat(polls).isLessThan(1000);
+    }
+
+    @Test
+    void testCompletesWithCommonPoolParallelismOne() throws Exception {
+        var java = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+        var process = new ProcessBuilder(
+                java,
+                "-Djava.util.concurrent.ForkJoinPool.common.parallelism=1",
+                "-cp", System.getProperty("java.class.path"),
+                ParallelismOneProgram.class.getName())
+                .inheritIO()
+                .start();
+        var finished = process.waitFor(60, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+        }
+        assertThat(finished)
+                .as("a DefaultRunner program with ForkJoinPool.common.parallelism=1 should not livelock")
+                .isTrue();
+        assertThat(process.exitValue()).isZero();
+    }
+
+    public static class ParallelismOneProgram {
+        public static void main(String[] args) throws Exception {
+            var runner = new DeploymentImpl.DefaultRunner(
+                    Logger.getLogger("ParallelismOneProgram"), EngineLogger.ignore());
+            var result = runner.runAsync(() -> {
+                registerDelayedTask(runner, 250);
+                return 0;
+            }).get(45, TimeUnit.SECONDS);
+            System.exit(result.exitCode());
+        }
+    }
+
+    /**
+     * Registers a task that is completed from a plain thread after a delay, so
+     * that its async continuation has to run on the common pool, like the
+     * continuations of gRPC calls in a real program.
+     */
+    private static void registerDelayedTask(DeploymentImpl.DefaultRunner runner, long millis) {
+        var task = new CompletableFuture<Void>();
+        var thread = new Thread(() -> {
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            task.complete(null);
+        });
+        thread.start();
+        runner.registerTask("DefaultRunnerTest", task.thenApplyAsync(v -> v));
+    }
+}


### PR DESCRIPTION
On JDK <=25, the default executor was the common ForJoinPool only if parallelism was at least 2.  Below that it was a separate new thread per task.  This changed in Java 25, so when we immediately re-enqueue `loopUntilDone`, the executor never gets a chance to do other tasks when parallelism is set to 1.

Fix this by giving the executor a little bit of time to allow other operations to be executed, and allowing the pulumi program to continue.  The only downside to this is that we take 10ms to notice when there are no more events, which is negligible compared to the time it takes a pulumi program.

Fixes #2270

Implemented by Claude, but it sounds reasonable.